### PR TITLE
DD-845: ignore failed exports/imports

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -54,6 +54,6 @@ logging:
       logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"
     - type: file
       archive: false
-      currentLogFilename: data/dd-verify-file-migration.log
+      currentLogFilename: dd-verify-file-migration.log
       archivedLogFilenamePattern: /var/log/dd-verify-file-migration-%d.log.gz
       archivedFileCount: 5

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -48,12 +48,13 @@ verificationDatabase:
 logging:
   level: INFO
   loggers:
-   "org.hibernate.engine.internal.StatisticalLoggingSessionEventListener": WARN
+    "org.hibernate.engine.internal.StatisticalLoggingSessionEventListener": WARN
   appenders:
     - type: console
       logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"
     - type: file
-      archive: false
-      currentLogFilename: dd-verify-file-migration.log
-      archivedLogFilenamePattern: /var/log/dd-verify-file-migration-%d.log.gz
+      archive: true
+      logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"
+      currentLogFilename: /var/opt/dans.knaw.nl/log/dd-verify-file-migration/dd-verify-file-migration.log
+      archivedLogFilenamePattern: /var/opt/dans.knaw.nl/log/dd-verify-file-migration/dd-verify-file-migration-%d.log
       archivedFileCount: 5

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -41,3 +41,19 @@ verificationDatabase:
   properties:
     hibernate.dialect: 'org.hibernate.dialect.PostgreSQL92Dialect'
     hibernate.hbm2ddl.auto: update
+
+#
+# See https://www.dropwizard.io/en/latest/manual/configuration.html#logging
+#
+logging:
+  level: INFO
+  loggers:
+   "org.hibernate.engine.internal.StatisticalLoggingSessionEventListener": WARN
+  appenders:
+    - type: console
+      logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"
+    - type: file
+      archive: false
+      currentLogFilename: data/dd-verify-file-migration.log
+      archivedLogFilenamePattern: /var/log/dd-verify-file-migration-%d.log.gz
+      archivedFileCount: 5

--- a/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromDataverseCommand.java
+++ b/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromDataverseCommand.java
@@ -100,7 +100,9 @@ public class LoadFromDataverseCommand extends DefaultConfigEnvironmentCommand<Dd
         else {
             log.info("Loading DOIs found in {}", file);
             for(CSVRecord r: FedoraToBagCsv.parse(new File(file))) {
-                proxy.loadFromDataset("doi:"+new FedoraToBagCsv(r).getDoi());
+                FedoraToBagCsv fedoraToBagCsv = new FedoraToBagCsv(r);
+                if (fedoraToBagCsv.getComment().contains("OK"))
+                    proxy.loadFromDataset("doi:"+ fedoraToBagCsv.getDoi());
             }
         }
     }

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -22,6 +22,7 @@ import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.DataFile;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.hsqldb.lib.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class DataverseLoader {
     }
 
     public void loadFromDataset(String doi) {
-        if (doi == null)
+        if (StringUtil.isEmpty(doi))
             return; // workaround
         log.info("Reading {} from dataverse", doi);
         List<DatasetVersion> versions;
@@ -52,12 +53,12 @@ public class DataverseLoader {
             versions = client.dataset(doi).getAllVersions().getData();
         }
         catch (UnrecognizedPropertyException e) {
-            log.error("skipping {} {}", doi, e.getMessage());
+            log.error("Skipping {} {}", doi, e.getMessage());
             return;
         }
         catch (Exception e) {
             log.error("Could not retrieve file metas for DOI: {}", doi, e);
-            throw new RuntimeException(e);
+            return;
         }
         for (DatasetVersion v : versions) {
             int fileCount = 0;

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Locale;
 
 public class DataverseLoader {
     private static final Logger log = LoggerFactory.getLogger(DataverseLoader.class);
@@ -57,7 +58,10 @@ public class DataverseLoader {
             return;
         }
         catch (Exception e) {
-            log.error("Could not retrieve file metas for DOI: {}", doi, e);
+            if (e.getMessage().toLowerCase().contains("not found"))
+                log.error("{} {} {}", doi, e.getClass(), e.getMessage());
+            else
+                log.error("Could not retrieve file metas for DOI: {}", doi, e);
             return;
         }
         for (DatasetVersion v : versions) {


### PR DESCRIPTION
Fixes DD-845: ignore failed exports/imports

# Description of changes
* skip records without OK in comment column
* [x] not found datasets should not cause a run time exception
* [x] deploy logging configuration

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
