### PR TITLE
DD-848 + DD-843: add embargoDate to expected/actual tables and accessibleTo to actual

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
             <artifactId>easymock</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,6 @@
             <artifactId>easymock</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -11,16 +11,27 @@ server:
       # Replace with port number unique for this service
       port: 20001
 
+#
 # for load-from-vault
+#
+
 bagStoreBaseUri: 'http://localhost:20110/'
 bagIndexBaseUri: 'http://localhost:20120/'
 
+#
 #for load-from-dataverse
+#
 dataverse:
   baseUrl: 'http://localhost:8080/'
   apiKey: changeme
 
-# for load-from-fedora, null on a datastation (read system without easy_db)
+#
+# for load-from-fedora
+#
+
+solrBaseUri: 'http://localhost:8080/solr/'
+
+# null on a datastation (read system without easy_db)
 easyDb:
   driverClass: org.postgresql.Driver
   url: 'jdbc:postgresql://localhost:5432/easy_db'
@@ -31,7 +42,10 @@ easyDb:
     hibernate.dialect: 'org.hibernate.dialect.PostgreSQL92Dialect'
     hibernate.hbm2ddl.auto: validate
 
+#
 # for all load-from commands
+#
+
 verificationDatabase:
   driverClass: org.postgresql.Driver
   url: 'jdbc:postgresql://localhost:5432/dd_verify_file_migration'

--- a/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
+++ b/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
@@ -40,6 +40,10 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
   private URI bagIndexBaseUri;
 
   @Valid
+  @NotNull
+  private URI solrBaseUri;
+
+  @Valid
   @Nullable
   private DataSourceFactory easyDb = new DataSourceFactory();
 
@@ -87,5 +91,13 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
 
   public void setBagIndexBaseUri(URI bagIndexBaseUri) {
     this.bagIndexBaseUri = bagIndexBaseUri;
+  }
+
+  public URI getSolrBaseUri() {
+    return solrBaseUri;
+  }
+
+  public void setSolrBaseUri(URI solrBaseUri) {
+    this.solrBaseUri = solrBaseUri;
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.filemigration.api;
 
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -63,6 +64,10 @@ public class ActualFile {
   @Column(length = 60)
   private String storage_id = "";
 
+  @Nullable
+  @Column()
+  private String embargo_date;
+
   public int getMajor_version_nr() {
     return major_version_nr;
   }
@@ -103,6 +108,15 @@ public class ActualFile {
     this.sha1_checksum = sha1_checksum;
   }
 
+  @Nullable
+  public String getEmbargo_date() {
+    return embargo_date;
+  }
+
+  public void setEmbargo_date(@Nullable String embargo_date) {
+    this.embargo_date = embargo_date;
+  }
+
   public String getDoi() {
     return doi;
   }
@@ -113,21 +127,27 @@ public class ActualFile {
 
   @Override
   public String toString() {
-    return "ActualFile{" + "doi='" + doi + '\'' + ", actual_path='" + actual_path + '\'' + ", major_version_nr=" + major_version_nr + ", minor_version_nr=" + minor_version_nr + ", sha1_checksum='" + sha1_checksum + '\'' + ", storage_id='" + storage_id + '\'' + '}';
+    return "ActualFile{" +
+            "doi='" + doi + '\'' +
+            ", actual_path='" + actual_path + '\'' +
+            ", major_version_nr=" + major_version_nr +
+            ", minor_version_nr=" + minor_version_nr +
+            ", sha1_checksum='" + sha1_checksum + '\'' +
+            ", storage_id='" + storage_id + '\'' +
+            ", embargo_date='" + embargo_date + '\'' +
+            '}';
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     ActualFile that = (ActualFile) o;
-    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(storage_id, that.storage_id);
+    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(storage_id, that.storage_id) && Objects.equals(embargo_date, that.embargo_date);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr, sha1_checksum, storage_id);
+    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr, sha1_checksum, storage_id, embargo_date);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.filemigration.api;
 
+import org.hsqldb.lib.StringUtil;
+import org.joda.time.DateTime;
+
 import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -113,8 +116,9 @@ public class ActualFile {
     return embargo_date;
   }
 
-  public void setEmbargo_date(@Nullable String embargo_date) {
-    this.embargo_date = embargo_date;
+  public void setEmbargo_date(@Nullable String dateAvailable) {
+    if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
+      this.embargo_date = dateAvailable;
   }
 
   public String getDoi() {

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -67,6 +67,9 @@ public class ActualFile {
   @Column(length = 60)
   private String storage_id = "";
 
+  @Column()
+  private String accessibleTo;
+
   @Nullable
   @Column()
   private String embargo_date;
@@ -111,6 +114,18 @@ public class ActualFile {
     this.sha1_checksum = sha1_checksum;
   }
 
+  public String getAccessibleTo() {
+    return accessibleTo;
+  }
+
+  public void setAccessibleTo(boolean fileIsRestricted, boolean datasetHasAccessRequestEnabled) {
+    if (!fileIsRestricted)
+      this.accessibleTo = "ANONYMOUS";
+    else if (datasetHasAccessRequestEnabled)
+      this.accessibleTo = "RESTRICTED_REQUEST";
+    else this.accessibleTo = "NONE";
+  }
+
   @Nullable
   public String getEmbargo_date() {
     return embargo_date;
@@ -138,6 +153,7 @@ public class ActualFile {
             ", minor_version_nr=" + minor_version_nr +
             ", sha1_checksum='" + sha1_checksum + '\'' +
             ", storage_id='" + storage_id + '\'' +
+            ", accessibleTo='" + accessibleTo + '\'' +
             ", embargo_date='" + embargo_date + '\'' +
             '}';
   }
@@ -147,11 +163,11 @@ public class ActualFile {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ActualFile that = (ActualFile) o;
-    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(storage_id, that.storage_id) && Objects.equals(embargo_date, that.embargo_date);
+    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(storage_id, that.storage_id) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(embargo_date, that.embargo_date);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr, sha1_checksum, storage_id, embargo_date);
+    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr, sha1_checksum, storage_id, accessibleTo, embargo_date);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -18,11 +18,8 @@ package nl.knaw.dans.filemigration.api;
 import nl.knaw.dans.filemigration.core.FileRights;
 import nl.knaw.dans.filemigration.core.ManifestCsv;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.Table;
+import javax.annotation.Nullable;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity
@@ -36,8 +33,8 @@ public class ExpectedFile {
 
     public ExpectedFile(String doi, EasyFile easyFile, boolean removeOriginal) {
         final String path = removeOriginal
-            ? easyFile.getPath().replace("original/", "")
-            : easyFile.getPath();
+                ? easyFile.getPath().replace("original/", "")
+                : easyFile.getPath();
         final String dvPath = dvPath(path);
 
         setDoi(doi);
@@ -147,12 +144,27 @@ public class ExpectedFile {
     @Column()
     private String visibleTo;
 
+    @Nullable
+    @Column()
+    private String embargo_date;
+
     @Override
     public String toString() {
-        return "ExpectedFile{" + "doi='" + doi + '\'' + ", expected_path='" + expected_path + '\'' + ", removed_duplicate_file_count=" + removed_duplicate_file_count + ", removed_original_directory="
-            + removed_original_directory + ", sha1_checksum='" + sha1_checksum + '\'' + ", easy_file_id='" + easy_file_id + '\'' + ", fs_rdb_path='" + fs_rdb_path + '\'' + ", added_during_migration="
-            + added_during_migration + ", removed_thumbnail=" + removed_thumbnail + ", transformed_name=" + transformed_name + ", accessibleTo='" + accessibleTo + '\'' + ", visibleTo='" + visibleTo
-            + '\'' + '}';
+        return "ExpectedFile{" +
+                "doi='" + doi + '\'' +
+                ", expected_path='" + expected_path + '\'' +
+                ", removed_duplicate_file_count=" + removed_duplicate_file_count +
+                ", removed_original_directory=" + removed_original_directory +
+                ", sha1_checksum='" + sha1_checksum + '\'' +
+                ", easy_file_id='" + easy_file_id + '\'' +
+                ", fs_rdb_path='" + fs_rdb_path + '\'' +
+                ", added_during_migration=" + added_during_migration +
+                ", removed_thumbnail=" + removed_thumbnail +
+                ", transformed_name=" + transformed_name +
+                ", accessibleTo='" + accessibleTo + '\'' +
+                ", visibleTo='" + visibleTo + '\'' +
+                ", embargo_date='" + embargo_date + '\'' +
+                '}';
     }
 
     public boolean isTransformed_name() {
@@ -239,6 +251,15 @@ public class ExpectedFile {
         this.doi = doi;
     }
 
+    @Nullable
+    public String getEmbargo_date() {
+        return embargo_date;
+    }
+
+    public void setEmbargo_date(@Nullable String embargo_date) {
+        this.embargo_date = embargo_date;
+    }
+
     public String getAccessibleTo() {
         return accessibleTo;
     }
@@ -257,20 +278,14 @@ public class ExpectedFile {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ExpectedFile that = (ExpectedFile) o;
-        return removed_duplicate_file_count == that.removed_duplicate_file_count && removed_original_directory == that.removed_original_directory
-            && added_during_migration == that.added_during_migration && removed_thumbnail == that.removed_thumbnail && transformed_name == that.transformed_name && Objects.equals(doi, that.doi)
-            && Objects.equals(expected_path, that.expected_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(easy_file_id, that.easy_file_id) && Objects.equals(fs_rdb_path,
-            that.fs_rdb_path) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo);
+        return removed_duplicate_file_count == that.removed_duplicate_file_count && removed_original_directory == that.removed_original_directory && added_during_migration == that.added_during_migration && removed_thumbnail == that.removed_thumbnail && transformed_name == that.transformed_name && Objects.equals(doi, that.doi) && Objects.equals(expected_path, that.expected_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(easy_file_id, that.easy_file_id) && Objects.equals(fs_rdb_path, that.fs_rdb_path) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargo_date, that.embargo_date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, expected_path, removed_duplicate_file_count, removed_original_directory, sha1_checksum, easy_file_id, fs_rdb_path, added_during_migration, removed_thumbnail,
-            transformed_name, accessibleTo, visibleTo);
+        return Objects.hash(doi, expected_path, removed_duplicate_file_count, removed_original_directory, sha1_checksum, easy_file_id, fs_rdb_path, added_during_migration, removed_thumbnail, transformed_name, accessibleTo, visibleTo, embargo_date);
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.filemigration.api;
 
 import nl.knaw.dans.filemigration.core.FileRights;
 import nl.knaw.dans.filemigration.core.ManifestCsv;
+import org.hsqldb.lib.StringUtil;
+import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import javax.persistence.*;
@@ -256,8 +258,9 @@ public class ExpectedFile {
         return embargo_date;
     }
 
-    public void setEmbargo_date(@Nullable String embargo_date) {
-        this.embargo_date = embargo_date;
+    public void setEmbargo_date(@Nullable String dateAvailable) {
+        if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
+            this.embargo_date = dateAvailable;
     }
 
     public String getAccessibleTo() {

--- a/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromFedoraCommand.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.naming.ConfigurationException;
 import java.io.File;
+import java.net.URI;
 
 public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVerifyFileMigrationConfiguration> {
 
@@ -91,8 +92,8 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
         EasyFileLoader proxy = new UnitOfWorkAwareProxyFactory(easyBundle, expectedBundle)
             .create(
                 EasyFileLoaderImpl.class,
-                new Class[] { EasyFileDAO.class, ExpectedFileDAO.class },
-                new Object[] { easyFileDAO, expectedDAO }
+                new Class[] { EasyFileDAO.class, ExpectedFileDAO.class, URI.class},
+                new Object[] { easyFileDAO, expectedDAO, configuration.getSolrBaseUri()}
             );
         for (File file : namespace.<File> getList("csv")) {
             log.info(file.toString());

--- a/src/main/java/nl/knaw/dans/filemigration/core/DatasetRightsHandler.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DatasetRightsHandler.java
@@ -52,7 +52,7 @@ public class DatasetRightsHandler extends DefaultHandler {
     else if ("available".equalsIgnoreCase(localName)) {
       String dateAvailable = chars.toString();
       if (DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
-        defaultFileRights.setEmbargoDate(dateAvailable);
+        defaultFileRights.setEmbargoDate(dateAvailable.trim());
     }
   }
 

--- a/src/main/java/nl/knaw/dans/filemigration/core/DatasetRightsHandler.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DatasetRightsHandler.java
@@ -16,6 +16,8 @@
 
 package nl.knaw.dans.filemigration.core;
 
+import org.apache.http.client.utils.DateUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
@@ -26,6 +28,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 
 public class DatasetRightsHandler extends DefaultHandler {
 
@@ -33,7 +36,7 @@ public class DatasetRightsHandler extends DefaultHandler {
 
   private static final SAXParserFactory parserFactory = configureFactory();
   private StringBuilder chars; // collected since the last startElement
-  private FileRights defaultFileRights; // collected since startElement of the last <file>
+  private final FileRights defaultFileRights = new FileRights();
 
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {
@@ -44,7 +47,12 @@ public class DatasetRightsHandler extends DefaultHandler {
   public void endElement(String uri, String localName, String qName) {
 
     if ("accessRights".equalsIgnoreCase(localName)) {
-      defaultFileRights = new FileRights(chars.toString().toUpperCase());
+      defaultFileRights.setFileRights(chars.toString().toUpperCase());
+    }
+    else if ("available".equalsIgnoreCase(localName)) {
+      String dateAvailable = chars.toString();
+      if (DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
+        defaultFileRights.setEmbargoDate(dateAvailable);
     }
   }
 
@@ -54,9 +62,9 @@ public class DatasetRightsHandler extends DefaultHandler {
   }
 
   private FileRights get() {
-    if (defaultFileRights==null) {
-      log.warn("accessRights not found in dataset.xml");
-      return new FileRights("NO_ACCESS");
+    if (defaultFileRights.getAccessibleTo()==null) {
+      // note that embargoDate==null does not mean there was no date available
+      throw new IllegalArgumentException("Invalid dataset.xml: no accessRights");
     }
     return defaultFileRights;
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -76,9 +76,7 @@ public class DataverseLoader {
         String dl = fileMeta.getDirectoryLabel();
         String actual_path = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
         ActualFile actualFile = new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
-        String dateAvailable = f.getEmbargo().getDateAvailable();
-        if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
-            actualFile.setEmbargo_date(dateAvailable);
+        actualFile.setEmbargo_date(f.getEmbargo().getDateAvailable());
         return actualFile;
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -21,6 +21,7 @@ import nl.knaw.dans.filemigration.db.ActualFileDAO;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.DataFile;
+import nl.knaw.dans.lib.dataverse.model.file.Embargo;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.hsqldb.lib.StringUtil;
 import org.joda.time.DateTime;
@@ -76,7 +77,9 @@ public class DataverseLoader {
         String dl = fileMeta.getDirectoryLabel();
         String actual_path = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
         ActualFile actualFile = new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
-        actualFile.setEmbargo_date(f.getEmbargo().getDateAvailable());
+        Embargo embargo = f.getEmbargo();
+        if (embargo != null)
+            actualFile.setEmbargo_date(embargo.getDateAvailable());
         return actualFile;
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -65,18 +65,19 @@ public class DataverseLoader {
         for (DatasetVersion v : versions) {
             int fileCount = 0;
             for (FileMeta f : v.getFiles()) {
-                saveActual(toActual(f, doi, v.getVersionNumber(), v.getVersionMinorNumber()));
+                saveActual(toActual(f, doi, v.getVersionNumber(), v.getVersionMinorNumber(), v.isFileAccessRequest()));
                 ++fileCount;
             }
             log.info("Stored {} actual files for DOI {}, Version {}.{} State {}", fileCount, doi, v.getVersionNumber(), v.getVersionMinorNumber(), v.getVersionState());
         }
     }
 
-    private ActualFile toActual(FileMeta fileMeta, String doi, int majorVersion, int minorVersion) {
+    private ActualFile toActual(FileMeta fileMeta, String doi, int majorVersion, int minorVersion, boolean datasetHasAccessRequestEnabled) {
         DataFile f = fileMeta.getDataFile();
         String dl = fileMeta.getDirectoryLabel();
         String actual_path = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
         ActualFile actualFile = new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
+        actualFile.setAccessibleTo(fileMeta.getRestricted(), datasetHasAccessRequestEnabled);
         Embargo embargo = f.getEmbargo();
         if (embargo != null)
             actualFile.setEmbargo_date(embargo.getDateAvailable());

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -22,6 +22,8 @@ import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.DataFile;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.hsqldb.lib.StringUtil;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +75,10 @@ public class DataverseLoader {
         DataFile f = fileMeta.getDataFile();
         String dl = fileMeta.getDirectoryLabel();
         String actual_path = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
-        return new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
+        ActualFile actualFile = new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
+        String dateAvailable = f.getEmbargo().getDateAvailable();
+        if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
+            actualFile.setEmbargo_date(dateAvailable);
+        return actualFile;
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -21,12 +21,10 @@ import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
-import org.hsqldb.lib.StringUtil;
-import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -43,7 +43,8 @@ public class EasyFileLoader extends ExpectedLoader {
       // thus we don't write anything when reading fails
       if (!csv.getComment().contains("no payload"))
         fedoraFiles(csv);
-      FileRights fileRights = new FileRights("OPEN_ACCESS"); // TODO from dataset.xml <accessRight>?
+      FileRights fileRights = new FileRights();
+      fileRights.setFileRights("OPEN_ACCESS");// TODO from dataset.xml <accessRight> or solr?
       expectedMigrationFiles(csv.getDoi(), migrationFiles, fileRights);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -19,20 +19,32 @@ import nl.knaw.dans.filemigration.api.EasyFile;
 import nl.knaw.dans.filemigration.api.ExpectedFile;
 import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.hsqldb.lib.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
+
+import static nl.knaw.dans.filemigration.core.HttpHelper.executeReq;
 
 public class EasyFileLoader extends ExpectedLoader {
 
   private static final Logger log = LoggerFactory.getLogger(EasyFileLoader.class);
 
   private final EasyFileDAO easyFileDAO;
+  private URI solrUri;
 
-  public EasyFileLoader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO) {
+  public EasyFileLoader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri) {
     super(expectedDAO);
     this.easyFileDAO = easyFileDAO;
+    this.solrUri = solrBaseUri.resolve("datasets/select");
   }
 
   public void loadFromCsv(FedoraToBagCsv csv) {
@@ -41,18 +53,48 @@ public class EasyFileLoader extends ExpectedLoader {
     else {
       // read fedora files before adding expected migration files
       // thus we don't write anything when reading fails
+      FileRights datasetRights = getDatasetRights(csv.getDatasetId());
       if (!csv.getComment().contains("no payload"))
-        fedoraFiles(csv);
+        fedoraFiles(csv, datasetRights.getEmbargoDate());
+      expectedMigrationFiles(csv.getDoi(), migrationFiles, datasetRights);
+    }
+  }
+
+  @NotNull
+  private FileRights getDatasetRights(String datasetId) {
+    URIBuilder builder = new URIBuilder(solrUri)
+            .setParameter("q", "sid:\""+datasetId+"\"")
+            .setParameter("fl", "emd_date_available_formatted,dc_rights")
+            .setParameter("wt", "csv")
+            .setParameter("csv.header", "false")
+            .setParameter("version", "2.2");
+    try {
+      String line = executeReq(new HttpGet(builder.build()), false);
+      String dateAvailable = line
+              .replaceAll(",.*","");
+      String rights = line
+              .replaceAll("^[^,]*,","") // strip date
+              .replaceAll("^\"","") // strip leading quote
+              .replaceAll("\"$","") // strip trailing quote
+              .replaceAll(",.*",""); // strip licence URL and rights holder
       FileRights fileRights = new FileRights();
-      fileRights.setFileRights("OPEN_ACCESS");// TODO from dataset.xml <accessRight> or solr?
-      expectedMigrationFiles(csv.getDoi(), migrationFiles, fileRights);
+      fileRights.setEmbargoDate(dateAvailable);
+      fileRights.setFileRights(rights);
+      return fileRights;
+    } catch (IOException | URISyntaxException e) {
+      // expecting an empty line when not found, other errors are fatal
+      throw new IllegalStateException(e.getMessage(), e);
     }
   }
 
   /** note: easy-convert-bag-to-deposit does not add emd.xml to bags from the vault */
   private static final String[] migrationFiles = { "provenance.xml", "dataset.xml", "files.xml", "emd.xml" };
 
-  private void fedoraFiles(FedoraToBagCsv csv) {
+  /**
+   * @param csv         not null, record produced by easy-fedora-to-bag
+   * @param embargoDate null if data-available not in the future
+   */
+  private void fedoraFiles(FedoraToBagCsv csv, String embargoDate) {
     log.trace(csv.toString());
     List<EasyFile> easyFiles = getByDatasetId(csv);
     for (EasyFile f : easyFiles) {
@@ -62,6 +104,7 @@ public class EasyFileLoader extends ExpectedLoader {
       ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal);
       expected.setAccessibleTo(f.getAccessible_to());
       expected.setVisibleTo(f.getVisible_to());
+      expected.setEmbargo_date(embargoDate);
       retriedSave(expected);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -39,7 +39,7 @@ public class EasyFileLoader extends ExpectedLoader {
   private static final Logger log = LoggerFactory.getLogger(EasyFileLoader.class);
 
   private final EasyFileDAO easyFileDAO;
-  private URI solrUri;
+  private final URI solrUri;
 
   public EasyFileLoader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri) {
     super(expectedDAO);
@@ -61,7 +61,7 @@ public class EasyFileLoader extends ExpectedLoader {
   }
 
   @NotNull
-  private FileRights getDatasetRights(String datasetId) {
+  protected FileRights getDatasetRights(String datasetId) {
     URIBuilder builder = new URIBuilder(solrUri)
             .setParameter("q", "sid:\""+datasetId+"\"")
             .setParameter("fl", "emd_date_available_formatted,dc_rights")

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -78,7 +78,7 @@ public class EasyFileLoader extends ExpectedLoader {
               .replaceAll("\"$","") // strip trailing quote
               .replaceAll(",.*",""); // strip licence URL and rights holder
       FileRights fileRights = new FileRights();
-      fileRights.setEmbargoDate(dateAvailable);
+      fileRights.setEmbargoDate(dateAvailable.trim());
       fileRights.setFileRights(rights);
       return fileRights;
     } catch (IOException | URISyntaxException e) {

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoaderImpl.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoaderImpl.java
@@ -21,13 +21,14 @@ import nl.knaw.dans.filemigration.api.ExpectedFile;
 import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 
+import java.net.URI;
 import java.util.List;
 
-public class EasyFileLoaderImpl extends EasyFileLoader{
+public class EasyFileLoaderImpl extends EasyFileLoader {
 
-  public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO) {
-    super(easyFileDAO,expectedDAO);
-  }
+    public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri) {
+        super(easyFileDAO, expectedDAO, solrBaseUri);
+    }
 
   @UnitOfWork("easyBundle")
   public List<EasyFile> getByDatasetId(FedoraToBagCsv csv) {

--- a/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
@@ -32,7 +32,7 @@ public class ExpectedLoader {
     this.expectedDAO = expectedDAO;
   }
 
-  public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights fileRights) {
+  public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights datasetRights) {
     for (String f: migrationFiles) {
       ExpectedFile expectedFile = new ExpectedFile();
       expectedFile.setDoi(doi);
@@ -45,8 +45,8 @@ public class ExpectedLoader {
       expectedFile.setRemoved_original_directory(false);
       expectedFile.setRemoved_duplicate_file_count(0);
       expectedFile.setTransformed_name(false);
-      expectedFile.setVisibleTo(fileRights.getVisibleTo());
-      expectedFile.setAccessibleTo(fileRights.getAccessibleTo());
+      expectedFile.setVisibleTo(datasetRights.getVisibleTo());
+      expectedFile.setAccessibleTo(datasetRights.getAccessibleTo());
       retriedSave(expectedFile);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
@@ -47,6 +47,7 @@ public class ExpectedLoader {
       expectedFile.setTransformed_name(false);
       expectedFile.setVisibleTo(datasetRights.getVisibleTo());
       expectedFile.setAccessibleTo(datasetRights.getAccessibleTo());
+      expectedFile.setEmbargo_date(datasetRights.getEmbargoDate());
       retriedSave(expectedFile);
     }
   }
@@ -72,6 +73,7 @@ public class ExpectedLoader {
   }
 
   public void saveExpected(ExpectedFile expected) {
+      log.trace(expected.toString());
       expectedDAO.create(expected);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
@@ -27,6 +27,15 @@ public class FileRights implements Serializable {
 
   private String accessibleTo;
   private String visibleTo;
+  private String embargoDate;
+
+  public String getEmbargoDate() {
+    return embargoDate;
+  }
+
+  public void setEmbargoDate(String embargoDate) {
+    this.embargoDate = embargoDate;
+  }
 
   public String getAccessibleTo() {
     return accessibleTo;
@@ -46,7 +55,7 @@ public class FileRights implements Serializable {
 
   public FileRights() {}
 
-  public FileRights(String datasetAccessRights) {
+  public void setFileRights(String datasetAccessRights) {
     switch (datasetAccessRights) {
       case "OPEN_ACCESS":
         setAccessibleTo("ANONYMOUS");
@@ -74,26 +83,29 @@ public class FileRights implements Serializable {
       setAccessibleTo(defaultRights.getAccessibleTo());
     if(StringUtil.isEmpty(getVisibleTo()))
       setVisibleTo(defaultRights.getVisibleTo());
+    setEmbargoDate(defaultRights.getEmbargoDate());
     return this;
   }
 
   @Override
   public String toString() {
-    return "FileMetadata{" + "accessibleTo='" + accessibleTo + '\'' + ", visibleTo='" + visibleTo + '\'' + '}';
+    return "FileRights{" +
+            "accessibleTo='" + accessibleTo + '\'' +
+            ", visibleTo='" + visibleTo + '\'' +
+            ", embargoDate='" + embargoDate + '\'' +
+            '}';
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     FileRights that = (FileRights) o;
-    return Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo);
+    return Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargoDate, that.embargoDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(accessibleTo, visibleTo);
+    return Objects.hash(accessibleTo, visibleTo, embargoDate);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
@@ -16,9 +16,11 @@
 package nl.knaw.dans.filemigration.core;
 
 import org.hsqldb.lib.StringUtil;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -33,8 +35,9 @@ public class FileRights implements Serializable {
     return embargoDate;
   }
 
-  public void setEmbargoDate(String embargoDate) {
-    this.embargoDate = embargoDate;
+  public void setEmbargoDate(@Nullable String dateAvailable) {
+    if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
+      this.embargoDate = dateAvailable;
   }
 
   public String getAccessibleTo() {

--- a/src/main/java/nl/knaw/dans/filemigration/core/HttpHelper.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/HttpHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.filemigration.core;
 
 import org.apache.http.HttpResponse;

--- a/src/main/java/nl/knaw/dans/filemigration/core/HttpHelper.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/HttpHelper.java
@@ -1,0 +1,32 @@
+package nl.knaw.dans.filemigration.core;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class HttpHelper {
+    private static final HttpClient client = HttpClients.createDefault();
+    private static final Logger log = LoggerFactory.getLogger(HttpHelper.class);
+
+    public static String executeReq(HttpGet req, boolean logNotFound) throws IOException {
+        log.info("{}", req);
+        HttpResponse resp = client.execute(req);
+        int statusCode = resp.getStatusLine().getStatusCode();
+        if (statusCode == 404) {
+            if (logNotFound)
+                log.error("Could not find {}", req.getURI());
+            return "";
+        }
+        else if (statusCode < 200 || statusCode >= 300)
+            throw new IOException("not expected response code: " + statusCode);
+        else
+            return EntityUtils.toString(resp.getEntity()); // max size 2147483647L
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static nl.knaw.dans.filemigration.core.HttpHelper.executeReq;
+
 public class VaultLoader extends ExpectedLoader {
 
   private static final Logger log = LoggerFactory.getLogger(VaultLoader.class);
@@ -55,7 +57,6 @@ public class VaultLoader extends ExpectedLoader {
   private final URI bagStoreBaseUri;
   private final URI bagIndexBaseUri;
   private final URI bagSeqUri;
-  private final HttpClient client = HttpClients.createDefault();
   private final ObjectMapper mapper;
 
   public VaultLoader(ExpectedFileDAO expectedDAO, URI bagStoreBaseUri, URI bagIndexBaseUri) {
@@ -188,20 +189,5 @@ public class VaultLoader extends ExpectedLoader {
     catch (IOException | URISyntaxException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private String executeReq(HttpGet req, boolean logNotFound) throws IOException {
-    log.info("{}", req);
-    HttpResponse resp = client.execute(req);
-    int statusCode = resp.getStatusLine().getStatusCode();
-    if (statusCode == 404) {
-      if (logNotFound)
-        log.error("Could not find {}", req.getURI());
-      return "";
-    }
-    else if (statusCode < 200 || statusCode >= 300)
-      throw new IOException("not expected response code: " + statusCode);
-    else
-      return EntityUtils.toString(resp.getEntity()); // max size 2147483647L
   }
 }

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -21,6 +21,7 @@ import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 import org.easymock.EasyMock;
 import org.hibernate.exception.ConstraintViolationException;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
@@ -38,7 +39,20 @@ import static org.easymock.EasyMock.verify;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
-  private static final URI solrBaseURI = solrBaseUri();
+  
+  private static class Loader extends EasyFileLoader {
+
+    public Loader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO) {
+      super(easyFileDAO, expectedDAO, solrBaseUri());
+    }
+
+    @Override
+    protected @NotNull FileRights getDatasetRights(String datasetId) {
+      FileRights fileRights = new FileRights();
+      fileRights.setFileRights("NO_ACCESS");
+      return fileRights;
+    }
+  }
 
   static URI solrBaseUri(){
     try {
@@ -59,7 +73,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, expectedFileDAO, easyFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
+    new Loader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -71,7 +85,7 @@ public class EasyFileLoaderTest {
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
     EasyFileDAO easyFileDAO = createMock(EasyFileDAO.class);
     replay(csv, expectedFileDAO, easyFileDAO);
-    new EasyFileLoader(null, null, solrBaseURI).loadFromCsv(csv);
+    new Loader(null, null).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -85,7 +99,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
+    new Loader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -105,7 +119,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
+    new Loader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -125,7 +139,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
+    new Loader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -143,7 +157,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
+    new Loader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -166,8 +180,8 @@ public class EasyFileLoaderTest {
       expectedFile.setExpected_path("easy-migration/" + f);
       expectedFile.setAdded_during_migration(true);
       expectedFiles.add(expectedFile);
-      expectedFile.setAccessibleTo("ANONYMOUS");
-      expectedFile.setVisibleTo("ANONYMOUS");
+      expectedFile.setAccessibleTo("NONE");
+      expectedFile.setVisibleTo("NONE");
     }
     return expectedFiles;
   }

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -21,10 +21,10 @@ import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 import org.easymock.EasyMock;
 import org.hibernate.exception.ConstraintViolationException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
+import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -24,6 +24,8 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +38,16 @@ import static org.easymock.EasyMock.verify;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
+  private static final URI solrBaseURI = solrBaseUri();
+
+  static URI solrBaseUri(){
+    try {
+      return new URI("http://does.not.exist.dans.knaw.nl:8080/solr/");
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
 
   @Test
   public void skipNoPayload() {
@@ -47,7 +59,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, expectedFileDAO, easyFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -59,7 +71,7 @@ public class EasyFileLoaderTest {
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
     EasyFileDAO easyFileDAO = createMock(EasyFileDAO.class);
     replay(csv, expectedFileDAO, easyFileDAO);
-    new EasyFileLoader(null, null).loadFromCsv(csv);
+    new EasyFileLoader(null, null, solrBaseURI).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -73,7 +85,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -93,7 +105,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -113,7 +125,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -131,7 +143,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new EasyFileLoader(easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new EasyFileLoader(easyFileDAO, expectedFileDAO, solrBaseURI).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 

--- a/src/test/resources/ddm/embargoed.xml
+++ b/src/test/resources/ddm/embargoed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ddm:DDM
+        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:gml="http://www.opengis.net/gml" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
+    <ddm:profile>
+        <dc:title>Test update scenarios (First)</dc:title>
+        <dct:description>onderzoeksrapport</dct:description>
+        <dc:creator>Bergman, W.A.</dc:creator>
+        <ddm:created>2004</ddm:created>
+        <ddm:available>2062-02-14</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata/>
+</ddm:DDM>

--- a/src/test/resources/ddm/restricted.xml
+++ b/src/test/resources/ddm/restricted.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ddm:DDM
+        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:gml="http://www.opengis.net/gml" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
+    <ddm:profile>
+        <dc:title>Test update scenarios (First)</dc:title>
+        <dct:description>onderzoeksrapport</dct:description>
+        <dc:creator>Bergman, W.A.</dc:creator>
+        <ddm:created>2004</ddm:created>
+        <ddm:available>2012-02-14</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>REQUEST_PERMISSION</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata/>
+</ddm:DDM>

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -48,6 +48,8 @@ easyDb:
     hibernate.dialect: 'org.hibernate.dialect.PostgreSQL92Dialect'
     hibernate.hbm2ddl.auto: update
 
+solrBaseUri: 'http://deasy.dans.knaw.nl:8080/solr'
+
 verificationDatabase:
   driverClass: org.hsqldb.jdbcDriver
   url: 'jdbc:hsqldb:hsql://localhost:9001/verificationDatabase'

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -29,10 +29,10 @@ logging:
       currentLogFilename: data/dd-verify-file-migration.log
 
 # with tunnel ssh -L 18080:localhost:20110 USER@XXX.dans.knaw.nl
-bagStoreBaseUri: 'http://localhost:18080/'
+bagStoreBaseUri: 'http://deasy.dans.knaw.nl:20110/'
 
 # with tunnel ssh -L 28080:localhost:20120 USER@XXX.dans.knaw.nl
-bagIndexBaseUri: 'http://localhost:28080/'
+bagIndexBaseUri: 'http://deasy.dans.knaw.nl:20120/'
 
 dataverse:
   baseUrl: 'http://dar.dans.knaw.nl:8080/'


### PR DESCRIPTION
Fixes DD-848 + DD-843: add embargoDate to expected/actual tables and accessibleTo to actual

# Description of changes

add date-available as embargo date if in future


# How to test
Each with at least one dataset in the past and one in the future:
* [x] from vault, see #4
  (load sword2 examples embargoed and another)
* [x] from fedora, 
  * [x] from the project root: `start.sh load-from-fedora src/test/resources/deasy.csv` embargo-dates should all be null
  * [x] set date-available to the future for `https://deasy.dans.knaw.nl/ui/datasets/id/easy-dataset:9/tab/1` and repeat the step above. All files (including easy-migration/*) should now have an embargo-date
* [x] from dataverse, see #3 
  * [x] the default dataset of `dev_archaeology-2022-02-16` has no embargo
  * [x] create a dataset with an embargo on a file, restrict access to a file and enable request access on the dataset

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
