### PR TITLE
DD-566: add depositor/curator

### DIFF
--- a/src/main/assembly/dist/cfg/account-substitutes.csv
+++ b/src/main/assembly/dist/cfg/account-substitutes.csv
@@ -1,2 +1,1 @@
 removed-account, chosen-account
-user001,USer

--- a/src/main/assembly/dist/cfg/account-substitutes.csv
+++ b/src/main/assembly/dist/cfg/account-substitutes.csv
@@ -1,0 +1,2 @@
+removed-account, chosen-account
+user001,USer

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -69,6 +69,6 @@ logging:
     - type: file
       archive: true
       logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"
-      currentLogFilename: /var/opt/dans.knaw.nl/log/dd-verify-file-migration/dd-verify-file-migration.log
-      archivedLogFilenamePattern: /var/opt/dans.knaw.nl/log/dd-verify-file-migration/dd-verify-file-migration-%d.log
+      currentLogFilename: dd-verify-file-migration.log
+      archivedLogFilenamePattern: dd-verify-file-migration-%d.log
       archivedFileCount: 5

--- a/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
+++ b/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
@@ -19,24 +19,12 @@ package nl.knaw.dans.filemigration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
-import net.sourceforge.argparse4j.inf.Namespace;
 import nl.knaw.dans.lib.util.DataverseClientFactory;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.apache.commons.csv.CSVFormat.RFC4180;
 
 public class DdVerifyFileMigrationConfiguration extends Configuration {
   @Valid
@@ -63,7 +51,6 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
   @NotNull
   private DataSourceFactory verificationDatabase = new DataSourceFactory();
 
-  HashMap<String, String> accountSubstitutes = new HashMap<>();
 
   @JsonProperty("easyDb")
   public DataSourceFactory getEasyDb() {
@@ -77,27 +64,6 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
   @JsonProperty("verificationDatabase")
   public DataSourceFactory getVerificationDatabase() {
     return verificationDatabase;
-  }
-
-  public void loadAccountSubstitutes(Namespace namespace) throws IOException {
-    CSVFormat format = RFC4180.withHeader("old", "new")
-            .withDelimiter(',')
-            .withFirstRecordAsHeader()
-            .withRecordSeparator(System.lineSeparator());
-    String configDir = new File(namespace.getString("file")).getParent();
-    File csvFile = new File(configDir + "/account-substitutes.csv");
-    if (csvFile.exists() && 0 != csvFile.length()) {
-      List<CSVRecord> records = CSVParser.parse(new FileInputStream(csvFile), StandardCharsets.UTF_8, format).getRecords();
-      records.forEach(csvRecord -> accountSubstitutes.put(csvRecord.get("old"), csvRecord.get("new")));
-    }
-  }
-
-  public HashMap<String, String> getAccountSubstitutes() {
-    return accountSubstitutes;
-  }
-
-  public void setAccountSubstitutes(HashMap<String, String> accountSubstitutes) {
-    this.accountSubstitutes = accountSubstitutes;
   }
 
   public void setVerificationDatabase(DataSourceFactory dataSourceFactory) {

--- a/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
+++ b/src/main/java/nl/knaw/dans/filemigration/DdVerifyFileMigrationConfiguration.java
@@ -19,12 +19,24 @@ package nl.knaw.dans.filemigration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import net.sourceforge.argparse4j.inf.Namespace;
 import nl.knaw.dans.lib.util.DataverseClientFactory;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.commons.csv.CSVFormat.RFC4180;
 
 public class DdVerifyFileMigrationConfiguration extends Configuration {
   @Valid
@@ -51,6 +63,8 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
   @NotNull
   private DataSourceFactory verificationDatabase = new DataSourceFactory();
 
+  HashMap<String, String> accountSubstitutes = new HashMap<>();
+
   @JsonProperty("easyDb")
   public DataSourceFactory getEasyDb() {
     return easyDb;
@@ -63,6 +77,27 @@ public class DdVerifyFileMigrationConfiguration extends Configuration {
   @JsonProperty("verificationDatabase")
   public DataSourceFactory getVerificationDatabase() {
     return verificationDatabase;
+  }
+
+  public void loadAccountSubstitutes(Namespace namespace) throws IOException {
+    CSVFormat format = RFC4180.withHeader("old", "new")
+            .withDelimiter(',')
+            .withFirstRecordAsHeader()
+            .withRecordSeparator(System.lineSeparator());
+    String configDir = new File(namespace.getString("file")).getParent();
+    File csvFile = new File(configDir + "/account-substitutes.csv");
+    if (csvFile.exists() && 0 != csvFile.length()) {
+      List<CSVRecord> records = CSVParser.parse(new FileInputStream(csvFile), StandardCharsets.UTF_8, format).getRecords();
+      records.forEach(csvRecord -> accountSubstitutes.put(csvRecord.get("old"), csvRecord.get("new")));
+    }
+  }
+
+  public HashMap<String, String> getAccountSubstitutes() {
+    return accountSubstitutes;
+  }
+
+  public void setAccountSubstitutes(HashMap<String, String> accountSubstitutes) {
+    this.accountSubstitutes = accountSubstitutes;
   }
 
   public void setVerificationDatabase(DataSourceFactory dataSourceFactory) {

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -34,13 +34,13 @@ public class ActualFile {
 
   public ActualFile() {}
 
-  public ActualFile(String doi, String actual_path, int major_version_nr, int minor_version_nr, String sha1_checksum, String storage_id) {
+  public ActualFile(String doi, String actualPath, int majorVersionNr, int minorVersionNr, String sha1Checksum, String storageId) {
     this.doi = doi;
-    this.actual_path = actual_path;
-    this.major_version_nr = major_version_nr;
-    this.minor_version_nr = minor_version_nr;
-    this.sha1_checksum = sha1_checksum;
-    this.storage_id = storage_id;
+    this.actualPath = actualPath;
+    this.majorVersionNr = majorVersionNr;
+    this.minorVersionNr = minorVersionNr;
+    this.sha1Checksum = sha1Checksum;
+    this.storageId = storageId;
   }
   // most lengths from easy-dtap/provisioning/roles/easy-fs-rdb/templates/create-easy-db-tables.sql
   // doi length as in dd-dtap/shared-code/dataverse/scripts/database/create/create_v*.sql
@@ -50,68 +50,68 @@ public class ActualFile {
   private String doi;
 
   @Id
-  @Column(length = 1024) // TODO basic_file_meta has only 1000
-  private String actual_path;
+  @Column(name="actual_path",length = 1024) // TODO basic_file_meta has only 1000
+  private String actualPath;
 
   @Id
-  @Column()
-  private int major_version_nr;
+  @Column(name="major_version_nr")
+  private int majorVersionNr;
 
   @Id
-  @Column()
-  private int minor_version_nr;
+  @Column(name="minor_version_nr")
+  private int minorVersionNr;
 
-  @Column(length = 40)
-  private String sha1_checksum = "";
+  @Column(name="sha1_checksum",length = 40)
+  private String sha1Checksum = "";
 
-  @Column(length = 60)
-  private String storage_id = "";
+  @Column(name="storage_id",length = 60)
+  private String storageId = "";
 
-  @Column()
+  @Column(name="accessible_to")
   private String accessibleTo;
 
   @Nullable
-  @Column()
-  private String embargo_date;
+  @Column(name="embargo_date")
+  private String embargoDate;
 
-  public int getMajor_version_nr() {
-    return major_version_nr;
+  public int getMajorVersionNr() {
+    return majorVersionNr;
   }
 
-  public void setMajor_version_nr(int major_version_nr) {
-    this.major_version_nr = major_version_nr;
+  public void setMajorVersionNr(int majorVersionNr) {
+    this.majorVersionNr = majorVersionNr;
   }
 
-  public void setMinor_version_nr(int minor_version_nr) {
-    this.minor_version_nr = minor_version_nr;
+  public void setMinorVersionNr(int minorVersionNr) {
+    this.minorVersionNr = minorVersionNr;
   }
 
-  public int getMinor_version_nr() {
-    return minor_version_nr;
+  public int getMinorVersionNr() {
+    return minorVersionNr;
   }
 
-  public String getActual_path() {
-    return actual_path;
+  public String getActualPath() {
+    return actualPath;
   }
 
-  public void setActual_path(String actual_path) {
-    this.actual_path = actual_path;
+  public void setActualPath(String actualPath) {
+    this.actualPath = actualPath;
   }
 
-  public String getStorage_id() {
-    return storage_id;
+  public String getStorageId() {
+    return storageId;
   }
 
-  public void setStorage_id(String storage_id) {
-    this.storage_id = storage_id;
+  public void setStorageId(String storageId) {
+    this.storageId = storageId;
   }
 
-  public String getSha1_checksum() {
-    return sha1_checksum;
+  public String getSha1Checksum() {
+    return sha1Checksum;
   }
 
-  public void setSha1_checksum(String sha1_checksum) {
-    this.sha1_checksum = sha1_checksum;
+  public void setSha1Checksum(String sha1Checksum) {
+    this.sha1Checksum = sha1Checksum;
   }
 
   public String getAccessibleTo() {
@@ -127,13 +127,13 @@ public class ActualFile {
   }
 
   @Nullable
-  public String getEmbargo_date() {
-    return embargo_date;
+  public String getEmbargoDate() {
+    return embargoDate;
   }
 
-  public void setEmbargo_date(@Nullable String dateAvailable) {
+  public void setEmbargoDate(@Nullable String dateAvailable) {
     if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
-      this.embargo_date = dateAvailable;
+      this.embargoDate = dateAvailable;
   }
 
   public String getDoi() {
@@ -148,13 +148,13 @@ public class ActualFile {
   public String toString() {
     return "ActualFile{" +
             "doi='" + doi + '\'' +
-            ", actual_path='" + actual_path + '\'' +
-            ", major_version_nr=" + major_version_nr +
-            ", minor_version_nr=" + minor_version_nr +
-            ", sha1_checksum='" + sha1_checksum + '\'' +
-            ", storage_id='" + storage_id + '\'' +
+            ", actualPath='" + actualPath + '\'' +
+            ", majorVersionNr=" + majorVersionNr +
+            ", minorVersionNr=" + minorVersionNr +
+            ", sha1Checksum='" + sha1Checksum + '\'' +
+            ", storageId='" + storageId + '\'' +
             ", accessibleTo='" + accessibleTo + '\'' +
-            ", embargo_date='" + embargo_date + '\'' +
+            ", embargoDate='" + embargoDate + '\'' +
             '}';
   }
 
@@ -163,11 +163,11 @@ public class ActualFile {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ActualFile that = (ActualFile) o;
-    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(storage_id, that.storage_id) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(embargo_date, that.embargo_date);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(actualPath, that.actualPath) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(storageId, that.storageId) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(embargoDate, that.embargoDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr, sha1_checksum, storage_id, accessibleTo, embargo_date);
+    return Objects.hash(doi, actualPath, majorVersionNr, minorVersionNr, sha1Checksum, storageId, accessibleTo, embargoDate);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -61,6 +61,9 @@ public class ActualFile {
   @Column(name="minor_version_nr")
   private int minorVersionNr;
 
+  @Column()
+  private String curator;
+
   @Column(name="sha1_checksum",length = 40)
   private String sha1Checksum = "";
 
@@ -73,6 +76,18 @@ public class ActualFile {
   @Nullable
   @Column(name="embargo_date")
   private String embargoDate;
+
+  public String getCurator() {
+    return curator;
+  }
+
+  public void setCurator(String curator) {
+    this.curator = curator;
+  }
+
+  public void setAccessibleTo(String accessibleTo) {
+    this.accessibleTo = accessibleTo;
+  }
 
   public int getMajorVersionNr() {
     return majorVersionNr;
@@ -151,6 +166,7 @@ public class ActualFile {
             ", actualPath='" + actualPath + '\'' +
             ", majorVersionNr=" + majorVersionNr +
             ", minorVersionNr=" + minorVersionNr +
+            ", curator='" + curator + '\'' +
             ", sha1Checksum='" + sha1Checksum + '\'' +
             ", storageId='" + storageId + '\'' +
             ", accessibleTo='" + accessibleTo + '\'' +
@@ -163,11 +179,11 @@ public class ActualFile {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ActualFile that = (ActualFile) o;
-    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(actualPath, that.actualPath) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(storageId, that.storageId) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(embargoDate, that.embargoDate);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(actualPath, that.actualPath) && Objects.equals(curator, that.curator) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(storageId, that.storageId) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(embargoDate, that.embargoDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, actualPath, majorVersionNr, minorVersionNr, sha1Checksum, storageId, accessibleTo, embargoDate);
+    return Objects.hash(doi, actualPath, majorVersionNr, minorVersionNr, curator, sha1Checksum, storageId, accessibleTo, embargoDate);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFile.java
@@ -19,11 +19,7 @@ import org.hsqldb.lib.StringUtil;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/nl/knaw/dans/filemigration/api/ActualFileKey.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ActualFileKey.java
@@ -20,22 +20,20 @@ import java.util.Objects;
 
 public class ActualFileKey implements Serializable {
   private String doi;
-  private String actual_path;
-  private int major_version_nr;
-  private int minor_version_nr;
+  private String actualPath;
+  private int majorVersionNr;
+  private int minorVersionNr;
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     ActualFileKey that = (ActualFileKey) o;
-    return major_version_nr == that.major_version_nr && minor_version_nr == that.minor_version_nr && Objects.equals(doi, that.doi) && Objects.equals(actual_path, that.actual_path);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(actualPath, that.actualPath);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, actual_path, major_version_nr, minor_version_nr);
+    return Objects.hash(doi, actualPath, majorVersionNr, minorVersionNr);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
@@ -15,13 +15,7 @@
  */
 package nl.knaw.dans.filemigration.api;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.QueryHint;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.util.Objects;
 
 // order by in decreasing numeric order, thus earlier versions become duplicates

--- a/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 // order by in decreasing numeric order, thus earlier versions become duplicates
 @NamedQueries({ @NamedQuery(name = "EasyFile.findByDatasetId",
-                            query = "SELECT ef FROM EasyFile ef WHERE ef.dataset_sid = :dataset_sid ORDER BY length(ef.pid) desc, ef.pid desc",
+                            query = "SELECT ef FROM EasyFile ef WHERE ef.datasetSid = :datasetSid ORDER BY length(ef.pid) desc, ef.pid desc",
                             hints = {
                                 @QueryHint(
                                     name = "org.hibernate.readOnly",
@@ -39,7 +39,7 @@ import java.util.Objects;
 @Table(name = "easy_files")
 public class EasyFile {
     public static final String FIND_BY_DATASET_ID = "EasyFile.findByDatasetId";
-    public static final String DATASET_ID = "dataset_sid";
+    public static final String DATASET_ID = "datasetSid";
 
     public EasyFile() {
     }
@@ -90,7 +90,7 @@ public class EasyFile {
     @Column(name="accessible_to",nullable = false)
     private String accessibleTo = "";
 
-    @Column(name="sha1_checksum")
+    @Column(name="sha1checksum")
     private String sha1Checksum = "";
 
     @Override

--- a/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/EasyFile.java
@@ -44,30 +44,30 @@ public class EasyFile {
     public EasyFile() {
     }
 
-    public EasyFile(String pid, String parent_sid, String dataset_sid, String path, String filename, long size, String mimetype, String creator_role, String visible_to, String accessible_to,
+    public EasyFile(String pid, String parentSid, String datasetSid, String path, String filename, long size, String mimetype, String creatorRole, String visibleTo, String accessibleTo,
         String sha1checksum) {
         this.pid = pid;
-        this.parent_sid = parent_sid;
-        this.dataset_sid = dataset_sid;
+        this.parentSid = parentSid;
+        this.datasetSid = datasetSid;
         this.path = path;
         this.filename = filename;
         this.size = size;
         this.mimetype = mimetype;
-        this.creator_role = creator_role;
-        this.visible_to = visible_to;
-        this.accessible_to = accessible_to;
-        this.sha1checksum = sha1checksum;
+        this.creatorRole = creatorRole;
+        this.visibleTo = visibleTo;
+        this.accessibleTo = accessibleTo;
+        this.sha1Checksum = sha1checksum;
     }
 
     @Id
     @Column(nullable = false)
     private String pid = "";
 
-    @Column(nullable = false)
-    private String parent_sid = "";
+    @Column(name="parent_sid",nullable = false)
+    private String parentSid = "";
 
-    @Column(nullable = false)
-    private String dataset_sid = "";
+    @Column(name="dataset_sid",nullable = false)
+    private String datasetSid = "";
 
     @Column()
     private String path = "";
@@ -81,55 +81,65 @@ public class EasyFile {
     @Column(nullable = false)
     private String mimetype = "";
 
-    @Column(nullable = false)
-    private String creator_role = "";
+    @Column(name="creator_role",nullable = false)
+    private String creatorRole = "";
 
-    @Column(nullable = false)
-    private String visible_to = "";
+    @Column(name="visible_to",nullable = false)
+    private String visibleTo = "";
 
-    @Column(nullable = false)
-    private String accessible_to = "";
+    @Column(name="accessible_to",nullable = false)
+    private String accessibleTo = "";
 
-    @Column()
-    private String sha1checksum = "";
+    @Column(name="sha1_checksum")
+    private String sha1Checksum = "";
 
     @Override
     public String toString() {
-        return "EasyFile{" + "pid='" + pid + '\'' + ", parent_sid='" + parent_sid + '\'' + ", dataset_sid='" + dataset_sid + '\'' + ", path='" + path + '\'' + ", filename='" + filename + '\''
-            + ", size=" + size + ", mimetype='" + mimetype + '\'' + ", creator_role='" + creator_role + '\'' + ", visible_to='" + visible_to + '\'' + ", accessible_to='" + accessible_to + '\''
-            + ", sha1checksum='" + sha1checksum + '\'' + '}';
+        return "EasyFile{" +
+                "pid='" + pid + '\'' +
+                ", parentSid='" + parentSid + '\'' +
+                ", datasetSid='" + datasetSid + '\'' +
+                ", path='" + path + '\'' +
+                ", filename='" + filename + '\'' +
+                ", size=" + size +
+                ", mimetype='" + mimetype + '\'' +
+                ", creatorRole='" + creatorRole + '\'' +
+                ", visibleTo='" + visibleTo + '\'' +
+                ", accessibleTo='" + accessibleTo + '\'' +
+                ", sha1Checksum='" + sha1Checksum + '\'' +
+                '}';
     }
 
-    public String getSha1checksum() {
-        return sha1checksum;
+    public String getSha1Checksum() {
+        return sha1Checksum;
     }
 
-    public void setSha1checksum(String sha1checksum) {
-        this.sha1checksum = sha1checksum;
+    public void setSha1Checksum(String sha1Checksum) {
+        this.sha1Checksum = sha1Checksum;
     }
 
-    public String getAccessible_to() {
-        return accessible_to;
+    public String getAccessibleTo() {
+        return accessibleTo;
     }
 
-    public void setAccessible_to(String accessible_to) {
-        this.accessible_to = accessible_to;
+    public void setAccessibleTo(String accessibleTo) {
+        this.accessibleTo = accessibleTo;
     }
 
-    public String getVisible_to() {
-        return visible_to;
+    public String getVisibleTo() {
+        return visibleTo;
     }
 
-    public void setVisible_to(String visible_to) {
-        this.visible_to = visible_to;
+    public void setVisibleTo(String visibleTo) {
+        this.visibleTo = visibleTo;
     }
 
-    public String getCreator_role() {
-        return creator_role;
+    public String getCreatorRole() {
+        return creatorRole;
     }
 
-    public void setCreator_role(String creator_role) {
-        this.creator_role = creator_role;
+    public void setCreatorRole(String creatorRole) {
+        this.creatorRole = creatorRole;
     }
 
     public String getMimetype() {
@@ -164,20 +174,20 @@ public class EasyFile {
         this.path = path;
     }
 
-    public String getDataset_sid() {
-        return dataset_sid;
+    public String getDatasetSid() {
+        return datasetSid;
     }
 
-    public void setDataset_sid(String dataset_sid) {
-        this.dataset_sid = dataset_sid;
+    public void setDatasetSid(String datasetSid) {
+        this.datasetSid = datasetSid;
     }
 
-    public String getParent_sid() {
-        return parent_sid;
+    public String getParentSid() {
+        return parentSid;
     }
 
-    public void setParent_sid(String parent_sid) {
-        this.parent_sid = parent_sid;
+    public void setParentSid(String parentSid) {
+        this.parentSid = parentSid;
     }
 
     public String getPid() {
@@ -190,18 +200,14 @@ public class EasyFile {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         EasyFile easyFile = (EasyFile) o;
-        return size == easyFile.size && Objects.equals(pid, easyFile.pid) && Objects.equals(parent_sid, easyFile.parent_sid) && Objects.equals(dataset_sid, easyFile.dataset_sid) && Objects.equals(
-            path, easyFile.path) && Objects.equals(filename, easyFile.filename) && Objects.equals(mimetype, easyFile.mimetype) && Objects.equals(creator_role, easyFile.creator_role) && Objects.equals(
-            visible_to, easyFile.visible_to) && Objects.equals(accessible_to, easyFile.accessible_to) && Objects.equals(sha1checksum, easyFile.sha1checksum);
+        return size == easyFile.size && Objects.equals(pid, easyFile.pid) && Objects.equals(parentSid, easyFile.parentSid) && Objects.equals(datasetSid, easyFile.datasetSid) && Objects.equals(path, easyFile.path) && Objects.equals(filename, easyFile.filename) && Objects.equals(mimetype, easyFile.mimetype) && Objects.equals(creatorRole, easyFile.creatorRole) && Objects.equals(visibleTo, easyFile.visibleTo) && Objects.equals(accessibleTo, easyFile.accessibleTo) && Objects.equals(sha1Checksum, easyFile.sha1Checksum);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pid, parent_sid, dataset_sid, path, filename, size, mimetype, creator_role, visible_to, accessible_to, sha1checksum);
+        return Objects.hash(pid, parentSid, datasetSid, path, filename, size, mimetype, creatorRole, visibleTo, accessibleTo, sha1Checksum);
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -116,6 +116,10 @@ public class ExpectedFile {
     private String expectedPath;
 
     @Id
+    @Column()
+    private String depositor;
+
+    @Id
     @Column(name="removed_duplicate_file_count")
     private int removedDuplicateFileCount;
 
@@ -147,14 +151,15 @@ public class ExpectedFile {
     private String visibleTo;
 
     @Nullable
-    @Column()
-    private String embargo_date;
+    @Column(name="embargo_date")
+    private String embargoDate;
 
     @Override
     public String toString() {
         return "ExpectedFile{" +
                 "doi='" + doi + '\'' +
                 ", expectedPath='" + expectedPath + '\'' +
+                ", depositor='" + depositor + '\'' +
                 ", removedDuplicateFileCount=" + removedDuplicateFileCount +
                 ", removedOriginalDirectory=" + removedOriginalDirectory +
                 ", sha1Checksum='" + sha1Checksum + '\'' +
@@ -165,7 +170,7 @@ public class ExpectedFile {
                 ", transformedName=" + transformedName +
                 ", accessibleTo='" + accessibleTo + '\'' +
                 ", visibleTo='" + visibleTo + '\'' +
-                ", embargo_date='" + embargo_date + '\'' +
+                ", embargoDate='" + embargoDate + '\'' +
                 '}';
     }
 
@@ -253,14 +258,22 @@ public class ExpectedFile {
         this.doi = doi;
     }
 
+    public String getDepositor() {
+        return depositor;
+    }
+
+    public void setDepositor(String depositor) {
+        this.depositor = depositor;
+    }
+
     @Nullable
-    public String getEmbargo_date() {
-        return embargo_date;
+    public String getEmbargoDate() {
+        return embargoDate;
     }
 
     public void setEmbargoDate(@Nullable String dateAvailable) {
         if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
-            this.embargo_date = dateAvailable;
+            this.embargoDate = dateAvailable;
     }
 
     public String getAccessibleTo() {
@@ -284,11 +297,11 @@ public class ExpectedFile {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExpectedFile that = (ExpectedFile) o;
-        return removedDuplicateFileCount == that.removedDuplicateFileCount && removedOriginalDirectory == that.removedOriginalDirectory && addedDuringMigration == that.addedDuringMigration && removedThumbnail == that.removedThumbnail && transformedName == that.transformedName && Objects.equals(doi, that.doi) && Objects.equals(expectedPath, that.expectedPath) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(easyFileId, that.easyFileId) && Objects.equals(fsRdbPath, that.fsRdbPath) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargo_date, that.embargo_date);
+        return removedDuplicateFileCount == that.removedDuplicateFileCount && removedOriginalDirectory == that.removedOriginalDirectory && addedDuringMigration == that.addedDuringMigration && removedThumbnail == that.removedThumbnail && transformedName == that.transformedName && Objects.equals(doi, that.doi) && Objects.equals(expectedPath, that.expectedPath) && Objects.equals(depositor, that.depositor) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(easyFileId, that.easyFileId) && Objects.equals(fsRdbPath, that.fsRdbPath) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargoDate, that.embargoDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, expectedPath, removedDuplicateFileCount, removedOriginalDirectory, sha1Checksum, easyFileId, fsRdbPath, addedDuringMigration, removedThumbnail, transformedName, accessibleTo, visibleTo, embargo_date);
+        return Objects.hash(doi, expectedPath, depositor, removedDuplicateFileCount, removedOriginalDirectory, sha1Checksum, easyFileId, fsRdbPath, addedDuringMigration, removedThumbnail, transformedName, accessibleTo, visibleTo, embargoDate);
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -130,10 +130,10 @@ public class ExpectedFile {
     @Column(name="transformed_name")
     private boolean transformedName;
 
-    @Column()
+    @Column(name="accessible_to")
     private String accessibleTo;
 
-    @Column()
+    @Column(name="visible_to")
     private String visibleTo;
 
     @Nullable

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -90,22 +90,6 @@ public class ExpectedFile {
         return s;
     }
 
-    public ExpectedFile(String doi, String expectedPath, int removedDuplicateFileCount, boolean removedOriginalDirectory, String sha1Checksum, String easyFileId, String fsRdbPath,
-        boolean addedDuringMigration, boolean removedThumbnail, boolean transformedName, String accessibleTo, String visibleTo) {
-        this.doi = doi;
-        this.expectedPath = expectedPath;
-        this.removedDuplicateFileCount = removedDuplicateFileCount;
-        this.removedOriginalDirectory = removedOriginalDirectory;
-        this.sha1Checksum = sha1Checksum;
-        this.easyFileId = easyFileId;
-        this.fsRdbPath = fsRdbPath;
-        this.addedDuringMigration = addedDuringMigration;
-        this.removedThumbnail = removedThumbnail;
-        this.transformedName = transformedName;
-        this.accessibleTo = accessibleTo;
-        this.visibleTo = visibleTo;
-    }
-
     // most lengths from easy-dtap/provisioning/roles/easy-fs-rdb/templates/create-easy-db-tables.sql
     // doi length as in dd-dtap/shared-code/dataverse/scripts/database/create/create_v*.sql
 

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -33,7 +33,7 @@ public class ExpectedFile {
     public ExpectedFile() {
     }
 
-    public ExpectedFile(String doi, EasyFile easyFile, boolean removeOriginal) {
+    public ExpectedFile(String doi, EasyFile easyFile, boolean removeOriginal, String depositor) {
         final String path = removeOriginal
                 ? easyFile.getPath().replace("original/", "")
                 : easyFile.getPath();
@@ -50,10 +50,11 @@ public class ExpectedFile {
         setRemovedThumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
         setRemovedOriginalDirectory(removeOriginal);
         setRemovedDuplicateFileCount(0);
+        setDepositor(depositor);
         setTransformedName(!path.equals(dvPath));
     }
 
-    public ExpectedFile(String doi, ManifestCsv manifestCsv, FileRights fileRights) {
+    public ExpectedFile(String doi, ManifestCsv manifestCsv, FileRights fileRights, String depositor) {
         final String path = manifestCsv.getPath();
         final String dvPath = dvPath(path);
 
@@ -68,6 +69,7 @@ public class ExpectedFile {
         setRemovedThumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
         setRemovedOriginalDirectory(false);
         setRemovedDuplicateFileCount(0);
+        setDepositor(depositor);
         setTransformedName(!path.equals(dvPath));
     }
 
@@ -263,6 +265,7 @@ public class ExpectedFile {
     }
 
     public void setDepositor(String depositor) {
+        // TODO mapping of easy-convert-bag-to-deposit/src/main/assembly/dist/cfg/account-substitutes.csv
         this.depositor = depositor;
     }
 

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFile.java
@@ -40,17 +40,17 @@ public class ExpectedFile {
         final String dvPath = dvPath(path);
 
         setDoi(doi);
-        setSha1_checksum(easyFile.getSha1checksum());
-        setEasy_file_id(easyFile.getPid());
-        setFs_rdb_path(easyFile.getPath());
-        setExpected_path(dvPath);
-        setAccessibleTo(easyFile.getAccessible_to());
-        setVisibleTo(easyFile.getVisible_to());
-        setAdded_during_migration(false);
-        setRemoved_thumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
-        setRemoved_original_directory(removeOriginal);
-        setRemoved_duplicate_file_count(0);
-        setTransformed_name(!path.equals(dvPath));
+        setSha1Checksum(easyFile.getSha1Checksum());
+        setEasyFileId(easyFile.getPid());
+        setFsRdbPath(easyFile.getPath());
+        setExpectedPath(dvPath);
+        setAccessibleTo(easyFile.getAccessibleTo());
+        setVisibleTo(easyFile.getVisibleTo());
+        setAddedDuringMigration(false);
+        setRemovedThumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
+        setRemovedOriginalDirectory(removeOriginal);
+        setRemovedDuplicateFileCount(0);
+        setTransformedName(!path.equals(dvPath));
     }
 
     public ExpectedFile(String doi, ManifestCsv manifestCsv, FileRights fileRights) {
@@ -58,17 +58,17 @@ public class ExpectedFile {
         final String dvPath = dvPath(path);
 
         setDoi(doi);
-        setSha1_checksum(manifestCsv.getSha1());
-        setEasy_file_id("");
-        setFs_rdb_path(manifestCsv.getPath());
-        setExpected_path(dvPath);
+        setSha1Checksum(manifestCsv.getSha1());
+        setEasyFileId("");
+        setFsRdbPath(manifestCsv.getPath());
+        setExpectedPath(dvPath);
         setAccessibleTo(fileRights.getAccessibleTo());
         setVisibleTo(fileRights.getVisibleTo());
-        setAdded_during_migration(false);
-        setRemoved_thumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
-        setRemoved_original_directory(false);
-        setRemoved_duplicate_file_count(0);
-        setTransformed_name(!path.equals(dvPath));
+        setAddedDuringMigration(false);
+        setRemovedThumbnail(path.toLowerCase().matches(".*thumbnails/.*_small.(png|jpg|tiff)"));
+        setRemovedOriginalDirectory(false);
+        setRemovedDuplicateFileCount(0);
+        setTransformedName(!path.equals(dvPath));
     }
 
     private String dvPath(String path) {
@@ -88,18 +88,18 @@ public class ExpectedFile {
         return s;
     }
 
-    public ExpectedFile(String doi, String expected_path, int removed_duplicate_file_count, boolean removed_original_directory, String sha1_checksum, String easy_file_id, String fs_rdb_path,
-        boolean added_during_migration, boolean removed_thumbnail, boolean transformed_name, String accessibleTo, String visibleTo) {
+    public ExpectedFile(String doi, String expectedPath, int removedDuplicateFileCount, boolean removedOriginalDirectory, String sha1Checksum, String easyFileId, String fsRdbPath,
+        boolean addedDuringMigration, boolean removedThumbnail, boolean transformedName, String accessibleTo, String visibleTo) {
         this.doi = doi;
-        this.expected_path = expected_path;
-        this.removed_duplicate_file_count = removed_duplicate_file_count;
-        this.removed_original_directory = removed_original_directory;
-        this.sha1_checksum = sha1_checksum;
-        this.easy_file_id = easy_file_id;
-        this.fs_rdb_path = fs_rdb_path;
-        this.added_during_migration = added_during_migration;
-        this.removed_thumbnail = removed_thumbnail;
-        this.transformed_name = transformed_name;
+        this.expectedPath = expectedPath;
+        this.removedDuplicateFileCount = removedDuplicateFileCount;
+        this.removedOriginalDirectory = removedOriginalDirectory;
+        this.sha1Checksum = sha1Checksum;
+        this.easyFileId = easyFileId;
+        this.fsRdbPath = fsRdbPath;
+        this.addedDuringMigration = addedDuringMigration;
+        this.removedThumbnail = removedThumbnail;
+        this.transformedName = transformedName;
         this.accessibleTo = accessibleTo;
         this.visibleTo = visibleTo;
     }
@@ -112,33 +112,33 @@ public class ExpectedFile {
     private String doi;
 
     @Id
-    @Column(length = 1024) // TODO basic_file_meta has only 1000
-    private String expected_path;
+    @Column(name="expected_path", length = 1024) // TODO basic_file_meta has only 1000
+    private String expectedPath;
 
     @Id
-    @Column()
-    private int removed_duplicate_file_count;
+    @Column(name="removed_duplicate_file_count")
+    private int removedDuplicateFileCount;
 
-    @Column()
-    private boolean removed_original_directory;
+    @Column(name="removed_original_directory")
+    private boolean removedOriginalDirectory;
 
-    @Column(length = 40)
-    private String sha1_checksum = "";
+    @Column(name="sha1_checksum", length = 40)
+    private String sha1Checksum = "";
 
-    @Column(length = 64)
-    private String easy_file_id = "";
+    @Column(name="easy_file_id", length = 64)
+    private String easyFileId = "";
 
-    @Column(length = 1024)
-    private String fs_rdb_path = "";
+    @Column(name="fs_rdb_path", length = 1024)
+    private String fsRdbPath = "";
 
-    @Column()
-    private boolean added_during_migration;
+    @Column(name="added_during_migration")
+    private boolean addedDuringMigration;
 
-    @Column()
-    private boolean removed_thumbnail;
+    @Column(name="removed_thumbnail")
+    private boolean removedThumbnail;
 
-    @Column()
-    private boolean transformed_name;
+    @Column(name="transformed_name")
+    private boolean transformedName;
 
     @Column()
     private String accessibleTo;
@@ -154,95 +154,95 @@ public class ExpectedFile {
     public String toString() {
         return "ExpectedFile{" +
                 "doi='" + doi + '\'' +
-                ", expected_path='" + expected_path + '\'' +
-                ", removed_duplicate_file_count=" + removed_duplicate_file_count +
-                ", removed_original_directory=" + removed_original_directory +
-                ", sha1_checksum='" + sha1_checksum + '\'' +
-                ", easy_file_id='" + easy_file_id + '\'' +
-                ", fs_rdb_path='" + fs_rdb_path + '\'' +
-                ", added_during_migration=" + added_during_migration +
-                ", removed_thumbnail=" + removed_thumbnail +
-                ", transformed_name=" + transformed_name +
+                ", expectedPath='" + expectedPath + '\'' +
+                ", removedDuplicateFileCount=" + removedDuplicateFileCount +
+                ", removedOriginalDirectory=" + removedOriginalDirectory +
+                ", sha1Checksum='" + sha1Checksum + '\'' +
+                ", easyFileId='" + easyFileId + '\'' +
+                ", fsRdbPath='" + fsRdbPath + '\'' +
+                ", addedDuringMigration=" + addedDuringMigration +
+                ", removedThumbnail=" + removedThumbnail +
+                ", transformedName=" + transformedName +
                 ", accessibleTo='" + accessibleTo + '\'' +
                 ", visibleTo='" + visibleTo + '\'' +
                 ", embargo_date='" + embargo_date + '\'' +
                 '}';
     }
 
-    public boolean isTransformed_name() {
-        return transformed_name;
+    public boolean isTransformedName() {
+        return transformedName;
     }
 
-    public void setTransformed_name(boolean transformed_name) {
-        this.transformed_name = transformed_name;
+    public void setTransformedName(boolean transformedName) {
+        this.transformedName = transformedName;
     }
 
-    public int getRemoved_duplicate_file_count() {
-        return removed_duplicate_file_count;
+    public int getRemovedDuplicateFileCount() {
+        return removedDuplicateFileCount;
     }
 
-    public void setRemoved_duplicate_file_count(int removed_duplicate_file_count) {
-        this.removed_duplicate_file_count = removed_duplicate_file_count;
+    public void setRemovedDuplicateFileCount(int removedDuplicateFileCount) {
+        this.removedDuplicateFileCount = removedDuplicateFileCount;
     }
 
     public void incRemoved_duplicate_file_count() {
-        this.removed_duplicate_file_count += 1;
+        this.removedDuplicateFileCount += 1;
     }
 
-    public boolean isRemoved_original_directory() {
-        return removed_original_directory;
+    public boolean isRemovedOriginalDirectory() {
+        return removedOriginalDirectory;
     }
 
-    public void setRemoved_original_directory(boolean removed_original_directory) {
-        this.removed_original_directory = removed_original_directory;
+    public void setRemovedOriginalDirectory(boolean removedOriginalDirectory) {
+        this.removedOriginalDirectory = removedOriginalDirectory;
     }
 
-    public boolean isRemoved_thumbnail() {
-        return removed_thumbnail;
+    public boolean isRemovedThumbnail() {
+        return removedThumbnail;
     }
 
-    public void setRemoved_thumbnail(boolean removed_thumbnail) {
-        this.removed_thumbnail = removed_thumbnail;
+    public void setRemovedThumbnail(boolean removedThumbnail) {
+        this.removedThumbnail = removedThumbnail;
     }
 
-    public boolean isAdded_during_migration() {
-        return added_during_migration;
+    public boolean isAddedDuringMigration() {
+        return addedDuringMigration;
     }
 
-    public void setAdded_during_migration(boolean added_during_migration) {
-        this.added_during_migration = added_during_migration;
+    public void setAddedDuringMigration(boolean addedDuringMigration) {
+        this.addedDuringMigration = addedDuringMigration;
     }
 
-    public String getExpected_path() {
-        return expected_path;
+    public String getExpectedPath() {
+        return expectedPath;
     }
 
-    public void setExpected_path(String expected_path) {
-        this.expected_path = expected_path;
+    public void setExpectedPath(String expectedPath) {
+        this.expectedPath = expectedPath;
     }
 
-    public String getFs_rdb_path() {
-        return fs_rdb_path;
+    public String getFsRdbPath() {
+        return fsRdbPath;
     }
 
-    public void setFs_rdb_path(String fs_rdb_path) {
-        this.fs_rdb_path = fs_rdb_path;
+    public void setFsRdbPath(String fsRdbPath) {
+        this.fsRdbPath = fsRdbPath;
     }
 
-    public String getEasy_file_id() {
-        return easy_file_id;
+    public String getEasyFileId() {
+        return easyFileId;
     }
 
-    public void setEasy_file_id(String easy_file_id) {
-        this.easy_file_id = easy_file_id;
+    public void setEasyFileId(String easyFileId) {
+        this.easyFileId = easyFileId;
     }
 
-    public String getSha1_checksum() {
-        return sha1_checksum;
+    public String getSha1Checksum() {
+        return sha1Checksum;
     }
 
-    public void setSha1_checksum(String sha1_checksum) {
-        this.sha1_checksum = sha1_checksum;
+    public void setSha1Checksum(String sha1Checksum) {
+        this.sha1Checksum = sha1Checksum;
     }
 
     public String getDoi() {
@@ -258,7 +258,7 @@ public class ExpectedFile {
         return embargo_date;
     }
 
-    public void setEmbargo_date(@Nullable String dateAvailable) {
+    public void setEmbargoDate(@Nullable String dateAvailable) {
         if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
             this.embargo_date = dateAvailable;
     }
@@ -284,11 +284,11 @@ public class ExpectedFile {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExpectedFile that = (ExpectedFile) o;
-        return removed_duplicate_file_count == that.removed_duplicate_file_count && removed_original_directory == that.removed_original_directory && added_during_migration == that.added_during_migration && removed_thumbnail == that.removed_thumbnail && transformed_name == that.transformed_name && Objects.equals(doi, that.doi) && Objects.equals(expected_path, that.expected_path) && Objects.equals(sha1_checksum, that.sha1_checksum) && Objects.equals(easy_file_id, that.easy_file_id) && Objects.equals(fs_rdb_path, that.fs_rdb_path) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargo_date, that.embargo_date);
+        return removedDuplicateFileCount == that.removedDuplicateFileCount && removedOriginalDirectory == that.removedOriginalDirectory && addedDuringMigration == that.addedDuringMigration && removedThumbnail == that.removedThumbnail && transformedName == that.transformedName && Objects.equals(doi, that.doi) && Objects.equals(expectedPath, that.expectedPath) && Objects.equals(sha1Checksum, that.sha1Checksum) && Objects.equals(easyFileId, that.easyFileId) && Objects.equals(fsRdbPath, that.fsRdbPath) && Objects.equals(accessibleTo, that.accessibleTo) && Objects.equals(visibleTo, that.visibleTo) && Objects.equals(embargo_date, that.embargo_date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, expected_path, removed_duplicate_file_count, removed_original_directory, sha1_checksum, easy_file_id, fs_rdb_path, added_during_migration, removed_thumbnail, transformed_name, accessibleTo, visibleTo, embargo_date);
+        return Objects.hash(doi, expectedPath, removedDuplicateFileCount, removedOriginalDirectory, sha1Checksum, easyFileId, fsRdbPath, addedDuringMigration, removedThumbnail, transformedName, accessibleTo, visibleTo, embargo_date);
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFileKey.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFileKey.java
@@ -19,31 +19,24 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class ExpectedFileKey implements Serializable {
 
   private String doi;
-  private String expected_path;
-  private int removed_duplicate_file_count;
+  private String expectedPath;
+  private int removedDuplicateFileCount;
 
-  // Equals contract implementation generated with IntelliJ
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ExpectedFileKey)) return false;
+    if (o == null || getClass() != o.getClass()) return false;
     ExpectedFileKey that = (ExpectedFileKey) o;
-    return new EqualsBuilder()
-        .append(doi, that.doi)
-        .append(expected_path, that.expected_path)
-        .append(removed_duplicate_file_count, that.removed_duplicate_file_count)
-        .isEquals();
+    return removedDuplicateFileCount == that.removedDuplicateFileCount && Objects.equals(doi, that.doi) && Objects.equals(expectedPath, that.expectedPath);
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37)
-        .append(doi)
-        .append(expected_path)
-        .append(removed_duplicate_file_count).toHashCode();
+    return Objects.hash(doi, expectedPath, removedDuplicateFileCount);
   }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFileKey.java
+++ b/src/main/java/nl/knaw/dans/filemigration/api/ExpectedFileKey.java
@@ -15,9 +15,6 @@
  */
 package nl.knaw.dans.filemigration.api;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromFedoraCommand.java
@@ -95,6 +95,7 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
                 new Class[] { EasyFileDAO.class, ExpectedFileDAO.class, URI.class},
                 new Object[] { easyFileDAO, expectedDAO, configuration.getSolrBaseUri()}
             );
+        configuration.loadAccountSubstitutes(namespace);
         for (File file : namespace.<File> getList("csv")) {
             log.info(file.toString());
             for (CSVRecord r : FedoraToBagCsv.parse(file)) {

--- a/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromVaultCommand.java
+++ b/src/main/java/nl/knaw/dans/filemigration/cli/LoadFromVaultCommand.java
@@ -86,6 +86,7 @@ public class LoadFromVaultCommand extends DefaultConfigEnvironmentCommand<DdVeri
         String uuid = namespace.getString("uuid");
         String file = namespace.getString("uuids");
         String store = namespace.getString("store");
+        configuration.loadAccountSubstitutes(namespace);
         if (uuid != null)
             proxy.loadFromVault(UUID.fromString(uuid));
         else if (file != null) {

--- a/src/main/java/nl/knaw/dans/filemigration/core/AccountSubstitutes.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/AccountSubstitutes.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.filemigration.core;
+
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.csv.CSVFormat.RFC4180;
+
+public class AccountSubstitutes {
+    private static final String removedAccount = "removed-account";
+    private static final String chosenAccount = "chosen-account";
+    private static final CSVFormat format = RFC4180.withHeader(removedAccount, chosenAccount)
+            .withDelimiter(',')
+            .withFirstRecordAsHeader()
+            .withIgnoreSurroundingSpaces()
+            .withRecordSeparator(System.lineSeparator());
+
+    static public Map<String, String> load(File configDir) {
+        File csvFile = new File(configDir + "/account-substitutes.csv");
+        if (!csvFile.exists() || 0 == csvFile.length()) {
+            throw new IllegalStateException("No (content in) " + csvFile);
+        }
+        List<CSVRecord> records;
+        try {
+            records = CSVParser.parse(new FileInputStream(csvFile), UTF_8, format).getRecords();
+        } catch (IOException e) {
+            throw new IllegalStateException("Can't read " + csvFile, e);
+        }
+        HashMap<String, String> accountSubstitutes = new HashMap<>();
+        records.forEach(csvRecord -> accountSubstitutes.put(
+                csvRecord.get(removedAccount), csvRecord.get(chosenAccount))
+        );
+        return accountSubstitutes;
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/filemigration/core/AccountSubstitutes.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/AccountSubstitutes.java
@@ -50,6 +50,8 @@ public class AccountSubstitutes {
         } catch (IOException e) {
             throw new IllegalStateException("Can't read " + csvFile, e);
         }
+        if (records.isEmpty())
+            throw new IllegalStateException("Empty " + csvFile);
         HashMap<String, String> accountSubstitutes = new HashMap<>();
         records.forEach(csvRecord -> accountSubstitutes.put(
                 csvRecord.get(removedAccount), csvRecord.get(chosenAccount))

--- a/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/DataverseLoader.java
@@ -77,12 +77,12 @@ public class DataverseLoader {
     private ActualFile toActual(FileMeta fileMeta, String doi, int majorVersion, int minorVersion, boolean datasetHasAccessRequestEnabled) {
         DataFile f = fileMeta.getDataFile();
         String dl = fileMeta.getDirectoryLabel();
-        String actual_path = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
-        ActualFile actualFile = new ActualFile(doi, actual_path, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
+        String actualPath = (dl == null ? "" : dl + "/") + fileMeta.getLabel();
+        ActualFile actualFile = new ActualFile(doi, actualPath, majorVersion, minorVersion, f.getChecksum().getValue(), f.getStorageIdentifier());
         actualFile.setAccessibleTo(fileMeta.getRestricted(), datasetHasAccessRequestEnabled);
         Embargo embargo = f.getEmbargo();
         if (embargo != null)
-            actualFile.setEmbargo_date(embargo.getDateAvailable());
+            actualFile.setEmbargoDate(embargo.getDateAvailable());
         return actualFile;
     }
 }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -52,9 +52,9 @@ public class EasyFileLoader extends ExpectedLoader {
       // thus we don't write anything when reading fails
       SolrFields solrFields = getSolrFields(csv.getDatasetId());
       FileRights datasetRights = new FileRights();
-      FileRights fileRights = new FileRights();
-      fileRights.setEmbargoDate(solrFields.available.trim());
-      fileRights.setFileRights(solrFields.rights);
+      datasetRights.setEmbargoDate(solrFields.available.trim());
+      datasetRights.setFileRights(solrFields.rights);
+      datasetRights.setFileRights(solrFields.rights);
       if (!csv.getComment().contains("no payload"))
         fedoraFiles(csv, datasetRights.getEmbargoDate(), solrFields.creator);
       expectedMigrationFiles(csv.getDoi(), migrationFiles, datasetRights, solrFields.creator);
@@ -83,19 +83,20 @@ public class EasyFileLoader extends ExpectedLoader {
   /**
    * @param csv         not null, record produced by easy-fedora-to-bag
    * @param embargoDate null if data-available not in the future
-   * @param creator
+   * @param depositor
    */
-  private void fedoraFiles(FedoraToBagCsv csv, String embargoDate, String creator) {
+  private void fedoraFiles(FedoraToBagCsv csv, String embargoDate, String depositor) {
     log.trace(csv.toString());
     List<EasyFile> easyFiles = getByDatasetId(csv);
     for (EasyFile f : easyFiles) {
       // note: biggest pdf/image option for europeana in easy-fedora-to-bag does not apply to migration
       log.trace("EasyFile = {}", f);
       final boolean removeOriginal = csv.getTransformation().startsWith("original") && f.getPath().startsWith("original/");
-      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal, creator);
+      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal, depositor);
       expected.setAccessibleTo(f.getAccessibleTo());
       expected.setVisibleTo(f.getVisibleTo());
       expected.setEmbargoDate(embargoDate);
+      expected.setDepositor(depositor);
       retriedSave(expected);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -100,9 +100,9 @@ public class EasyFileLoader extends ExpectedLoader {
       log.trace("EasyFile = {}", f);
       final boolean removeOriginal = csv.getTransformation().startsWith("original") && f.getPath().startsWith("original/");
       ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal);
-      expected.setAccessibleTo(f.getAccessible_to());
-      expected.setVisibleTo(f.getVisible_to());
-      expected.setEmbargo_date(embargoDate);
+      expected.setAccessibleTo(f.getAccessibleTo());
+      expected.setVisibleTo(f.getVisibleTo());
+      expected.setEmbargoDate(embargoDate);
       retriedSave(expected);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -24,6 +24,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,8 +39,8 @@ public class EasyFileLoader extends ExpectedLoader {
   private final EasyFileDAO easyFileDAO;
   private final URI solrUri;
 
-  public EasyFileLoader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri) {
-    super(expectedDAO);
+  public EasyFileLoader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri, File configDir) {
+    super(expectedDAO, configDir);
     this.easyFileDAO = easyFileDAO;
     this.solrUri = solrBaseUri.resolve("datasets/select");
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -24,6 +24,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -51,7 +52,7 @@ public class EasyFileLoader extends ExpectedLoader {
     else {
       // read fedora files before adding expected migration files
       // thus we don't write anything when reading fails
-      SolrFields solrFields = getSolrFields(csv.getDatasetId());
+      SolrFields solrFields = getDatasetRights(csv.getDatasetId());
       FileRights datasetRights = new FileRights();
       datasetRights.setEmbargoDate(solrFields.available.trim());
       datasetRights.setFileRights(solrFields.rights);
@@ -71,7 +72,7 @@ public class EasyFileLoader extends ExpectedLoader {
             .setParameter("csv.header", "false")
             .setParameter("version", "2.2");
     try {
-      String line = executeReq(new HttpGet(builder.build()), false);
+      String line = rightsFromSolr(datasetId);
       log.trace(line);
       return new SolrFields(line);
     } catch (IOException | URISyntaxException e) {

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -91,7 +91,7 @@ public class EasyFileLoader extends ExpectedLoader {
       // note: biggest pdf/image option for europeana in easy-fedora-to-bag does not apply to migration
       log.trace("EasyFile = {}", f);
       final boolean removeOriginal = csv.getTransformation().startsWith("original") && f.getPath().startsWith("original/");
-      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal);
+      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal, ""); // TODO depositor
       expected.setAccessibleTo(f.getAccessibleTo());
       expected.setVisibleTo(f.getVisibleTo());
       expected.setEmbargoDate(embargoDate);

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoader.java
@@ -56,7 +56,7 @@ public class EasyFileLoader extends ExpectedLoader {
       fileRights.setEmbargoDate(solrFields.available.trim());
       fileRights.setFileRights(solrFields.rights);
       if (!csv.getComment().contains("no payload"))
-        fedoraFiles(csv, datasetRights.getEmbargoDate());
+        fedoraFiles(csv, datasetRights.getEmbargoDate(), solrFields.creator);
       expectedMigrationFiles(csv.getDoi(), migrationFiles, datasetRights, solrFields.creator);
     }
   }
@@ -83,15 +83,16 @@ public class EasyFileLoader extends ExpectedLoader {
   /**
    * @param csv         not null, record produced by easy-fedora-to-bag
    * @param embargoDate null if data-available not in the future
+   * @param creator
    */
-  private void fedoraFiles(FedoraToBagCsv csv, String embargoDate) {
+  private void fedoraFiles(FedoraToBagCsv csv, String embargoDate, String creator) {
     log.trace(csv.toString());
     List<EasyFile> easyFiles = getByDatasetId(csv);
     for (EasyFile f : easyFiles) {
       // note: biggest pdf/image option for europeana in easy-fedora-to-bag does not apply to migration
       log.trace("EasyFile = {}", f);
       final boolean removeOriginal = csv.getTransformation().startsWith("original") && f.getPath().startsWith("original/");
-      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal, ""); // TODO depositor
+      ExpectedFile expected = new ExpectedFile(csv.getDoi(), f, removeOriginal, creator);
       expected.setAccessibleTo(f.getAccessibleTo());
       expected.setVisibleTo(f.getVisibleTo());
       expected.setEmbargoDate(embargoDate);

--- a/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoaderImpl.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/EasyFileLoaderImpl.java
@@ -21,13 +21,14 @@ import nl.knaw.dans.filemigration.api.ExpectedFile;
 import nl.knaw.dans.filemigration.db.EasyFileDAO;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 
+import java.io.File;
 import java.net.URI;
 import java.util.List;
 
 public class EasyFileLoaderImpl extends EasyFileLoader {
 
-    public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri) {
-        super(easyFileDAO, expectedDAO, solrBaseUri);
+    public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO, URI solrBaseUri, File configDir) {
+        super(easyFileDAO, expectedDAO, solrBaseUri, configDir);
     }
 
   @UnitOfWork("easyBundle")

--- a/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
@@ -22,14 +22,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
+import java.io.File;
+import java.util.Map;
 
 public class ExpectedLoader {
   private static final Logger log = LoggerFactory.getLogger(ExpectedLoader.class);
 
   private final ExpectedFileDAO expectedDAO;
+  private final Map<String, String> accountSubstitutes;
 
-  public ExpectedLoader(ExpectedFileDAO expectedDAO) {
+  public ExpectedLoader(ExpectedFileDAO expectedDAO, File configDir) {
+
     this.expectedDAO = expectedDAO;
+    this.accountSubstitutes = AccountSubstitutes.load(configDir);
   }
 
   public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights datasetRights, String creator) {
@@ -54,6 +59,9 @@ public class ExpectedLoader {
   }
 
   public void retriedSave(ExpectedFile expected) {
+    String depositor = expected.getDepositor();
+    if(accountSubstitutes.containsKey(depositor))
+      expected.setDepositor(accountSubstitutes.get(depositor));
     try {
       saveExpected(expected);
     } catch(PersistenceException e){

--- a/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
@@ -32,7 +32,7 @@ public class ExpectedLoader {
     this.expectedDAO = expectedDAO;
   }
 
-  public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights datasetRights) {
+  public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights datasetRights, String creator) {
     for (String f: migrationFiles) {
       ExpectedFile expectedFile = new ExpectedFile();
       expectedFile.setDoi(doi);
@@ -48,6 +48,7 @@ public class ExpectedLoader {
       expectedFile.setVisibleTo(datasetRights.getVisibleTo());
       expectedFile.setAccessibleTo(datasetRights.getAccessibleTo());
       expectedFile.setEmbargoDate(datasetRights.getEmbargoDate());
+      expectedFile.setDepositor(creator);
       retriedSave(expectedFile);
     }
   }

--- a/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/ExpectedLoader.java
@@ -36,18 +36,18 @@ public class ExpectedLoader {
     for (String f: migrationFiles) {
       ExpectedFile expectedFile = new ExpectedFile();
       expectedFile.setDoi(doi);
-      expectedFile.setSha1_checksum("");
-      expectedFile.setEasy_file_id("");
-      expectedFile.setFs_rdb_path("");
-      expectedFile.setExpected_path("easy-migration/" + f);
-      expectedFile.setAdded_during_migration(true);
-      expectedFile.setRemoved_thumbnail(false);
-      expectedFile.setRemoved_original_directory(false);
-      expectedFile.setRemoved_duplicate_file_count(0);
-      expectedFile.setTransformed_name(false);
+      expectedFile.setSha1Checksum("");
+      expectedFile.setEasyFileId("");
+      expectedFile.setFsRdbPath("");
+      expectedFile.setExpectedPath("easy-migration/" + f);
+      expectedFile.setAddedDuringMigration(true);
+      expectedFile.setRemovedThumbnail(false);
+      expectedFile.setRemovedOriginalDirectory(false);
+      expectedFile.setRemovedDuplicateFileCount(0);
+      expectedFile.setTransformedName(false);
       expectedFile.setVisibleTo(datasetRights.getVisibleTo());
       expectedFile.setAccessibleTo(datasetRights.getAccessibleTo());
-      expectedFile.setEmbargo_date(datasetRights.getEmbargoDate());
+      expectedFile.setEmbargoDate(datasetRights.getEmbargoDate());
       retriedSave(expectedFile);
     }
   }
@@ -60,7 +60,7 @@ public class ExpectedLoader {
       if (!(e.getCause() instanceof ConstraintViolationException))
         throw e;
       else {
-        if (expected.getRemoved_duplicate_file_count() > 10) {
+        if (expected.getRemovedDuplicateFileCount() > 10) {
           // TODO temporary safe guard?
           log.error("too many retries on duplicate file, skipping: {}", expected);
         }

--- a/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
@@ -26,6 +26,14 @@ import java.util.Objects;
 
 public class FileRights implements Serializable {
   private static final Logger log = LoggerFactory.getLogger(FileRights.class);
+  private final String known = "KNOWN";
+  private final String restricted_request = "RESTRICTED_REQUEST";
+  private final String none = "NONE";
+  private final String no_access = "NO_ACCESS";
+  private final String open_access = "OPEN_ACCESS";
+  private final String anonymous = "ANONYMOUS";
+  private final String open_access_for_registered_users = "OPEN_ACCESS_FOR_REGISTERED_USERS";
+  private final String request_permission = "REQUEST_PERMISSION";
 
   private String accessibleTo;
   private String visibleTo;
@@ -60,23 +68,23 @@ public class FileRights implements Serializable {
 
   public void setFileRights(String datasetAccessRights) {
     switch (datasetAccessRights) {
-      case "OPEN_ACCESS":
-        setAccessibleTo("ANONYMOUS");
-        setVisibleTo("ANONYMOUS");
+      case open_access:
+        setAccessibleTo(anonymous);
+        setVisibleTo(anonymous);
         break;
-      case "OPEN_ACCESS_FOR_REGISTERED_USERS":
-        setAccessibleTo("KNOWN");
-        setVisibleTo("KNOWN");
+      case open_access_for_registered_users:
+        setAccessibleTo(known);
+        setVisibleTo(known);
         break;
-      case "REQUEST_PERMISSION":
-        setAccessibleTo("RESTRICTED_REQUEST");
-        setVisibleTo("RESTRICTED_REQUEST");
+      case request_permission:
+        setAccessibleTo(restricted_request);
+        setVisibleTo(restricted_request);
         break;
       default:
         if (!"NO_ACCESS".equals(datasetAccessRights))
           log.warn("dataset rights not known: {}", datasetAccessRights);
-        setAccessibleTo("NONE");
-        setVisibleTo("NONE");
+        setAccessibleTo(none);
+        setVisibleTo(none);
         break;
     }
   }
@@ -85,35 +93,35 @@ public class FileRights implements Serializable {
     if (StringUtil.isEmpty(accessibleTo)) {
       setAccessibleTo(datasetRights.getAccessibleTo());
     } else switch (accessibleTo) {
-      case "KNOWN":
+      case known:
         switch (datasetRights.accessibleTo) {
-          case "RESTRICTED_REQUEST":
-          case "NONE":
+          case restricted_request:
+          case none:
             setAccessibleTo(datasetRights.getAccessibleTo());
             break;
         }
-      case "RESTRICTED_REQUEST":
-        if ("NONE".equals(datasetRights.accessibleTo))
-        setAccessibleTo("NONE");
+      case restricted_request:
+        if (none.equals(datasetRights.accessibleTo))
+        setAccessibleTo(none);
         break;
-      case "NO_ACCESS":
+      case no_access:
         break;
     }
     if (StringUtil.isEmpty(visibleTo)) {
       setVisibleTo(datasetRights.getVisibleTo());
     } else switch (visibleTo) {
-      case "KNOWN":
+      case known:
         switch (datasetRights.visibleTo) {
-          case "RESTRICTED_REQUEST":
-          case "NONE":
+          case restricted_request:
+          case none:
             setAccessibleTo(datasetRights.getAccessibleTo());
             break;
         }
-      case "RESTRICTED_REQUEST":
-        if ("NONE".equals(datasetRights.visibleTo))
-          setAccessibleTo("NONE");
+      case restricted_request:
+        if (none.equals(datasetRights.visibleTo))
+          setAccessibleTo(none);
         break;
-      case "NO_ACCESS":
+      case no_access:
         break;
     }
     setEmbargoDate(datasetRights.getEmbargoDate());

--- a/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
@@ -81,12 +81,42 @@ public class FileRights implements Serializable {
     }
   }
 
-  public FileRights applyDefaults(FileRights defaultRights){
-    if(StringUtil.isEmpty(getAccessibleTo()))
-      setAccessibleTo(defaultRights.getAccessibleTo());
-    if(StringUtil.isEmpty(getVisibleTo()))
-      setVisibleTo(defaultRights.getVisibleTo());
-    setEmbargoDate(defaultRights.getEmbargoDate());
+  public FileRights applyDefaults(FileRights datasetRights) {
+    if (StringUtil.isEmpty(accessibleTo)) {
+      setAccessibleTo(datasetRights.getAccessibleTo());
+    } else switch (accessibleTo) {
+      case "KNOWN":
+        switch (datasetRights.accessibleTo) {
+          case "RESTRICTED_REQUEST":
+          case "NONE":
+            setAccessibleTo(datasetRights.getAccessibleTo());
+            break;
+        }
+      case "RESTRICTED_REQUEST":
+        if ("NONE".equals(datasetRights.accessibleTo))
+        setAccessibleTo("NONE");
+        break;
+      case "NO_ACCESS":
+        break;
+    }
+    if (StringUtil.isEmpty(visibleTo)) {
+      setVisibleTo(datasetRights.getVisibleTo());
+    } else switch (visibleTo) {
+      case "KNOWN":
+        switch (datasetRights.visibleTo) {
+          case "RESTRICTED_REQUEST":
+          case "NONE":
+            setAccessibleTo(datasetRights.getAccessibleTo());
+            break;
+        }
+      case "RESTRICTED_REQUEST":
+        if ("NONE".equals(datasetRights.visibleTo))
+          setAccessibleTo("NONE");
+        break;
+      case "NO_ACCESS":
+        break;
+    }
+    setEmbargoDate(datasetRights.getEmbargoDate());
     return this;
   }
 

--- a/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/FileRights.java
@@ -36,8 +36,8 @@ public class FileRights implements Serializable {
   }
 
   public void setEmbargoDate(@Nullable String dateAvailable) {
-    if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable)) < 0)
-      this.embargoDate = dateAvailable;
+    if (!StringUtil.isEmpty(dateAvailable) && DateTime.now().compareTo(DateTime.parse(dateAvailable.trim())) < 0)
+      this.embargoDate = dateAvailable.trim();
   }
 
   public String getAccessibleTo() {

--- a/src/main/java/nl/knaw/dans/filemigration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/SolrFields.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.filemigration.core;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SolrFields {
+    static String requestedFields = "emd_date_available_formatted,dc_rights,dc_creator";
+    private static final CSVFormat solrFormat = CSVFormat.RFC4180.withDelimiter(',');
+    final String available;
+    final String rights;
+    final String creator;
+    SolrFields (String line) throws IOException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8));
+        CSVRecord record = CSVParser.parse(inputStream, StandardCharsets.UTF_8, solrFormat).getRecords().get(0);
+        available = record.get(0).trim();
+        rights = record.get(1)
+                .replaceAll("^[^,]*,","") // strip date
+                .replaceAll("^\"","") // strip leading quote
+                .replaceAll("\"$","") // strip trailing quote
+                .replaceAll(",.*",""); // strip licence URL and rights holder;
+        creator = record.get(2).trim();
+    }
+}

--- a/src/main/java/nl/knaw/dans/filemigration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/SolrFields.java
@@ -34,9 +34,7 @@ public class SolrFields {
         CSVRecord record = CSVParser.parse(inputStream, StandardCharsets.UTF_8, solrFormat).getRecords().get(0);
         available = record.get(0).trim();
         rights = record.get(1)
-                .replaceAll("^[^,]*,","") // strip date
-                .replaceAll("^\"","") // strip leading quote
-                .replaceAll("\"$","") // strip trailing quote
+                .replaceAll("^\"(.*)\"$","$1") // strip quotes
                 .replaceAll(",.*",""); // strip licence URL and rights holder;
         creator = record.get(2).trim();
     }

--- a/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
@@ -106,7 +106,7 @@ public class VaultLoader extends ExpectedLoader {
     Map<String, FileRights> filesXml = readFileMeta(uuid);
     FileRights defaultFileRights = readDefaultRights(uuid);
     readManifest(uuid).forEach(m -> createExpected(doi, m, filesXml, defaultFileRights));
-    expectedMigrationFiles(doi, migrationFiles, defaultFileRights);
+    expectedMigrationFiles(doi, migrationFiles, defaultFileRights,""); // TODO creator
   }
 
   private void createExpected(String doi, ManifestCsv m, Map<String, FileRights> fileRightsMap, FileRights defaultFileRights) {

--- a/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/VaultLoader.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,8 +53,8 @@ public class VaultLoader extends ExpectedLoader {
   private final URI bagSeqUri;
   private final ObjectMapper mapper;
 
-  public VaultLoader(ExpectedFileDAO expectedDAO, URI bagStoreBaseUri, URI bagIndexBaseUri) {
-    super(expectedDAO);
+  public VaultLoader(ExpectedFileDAO expectedDAO, URI bagStoreBaseUri, URI bagIndexBaseUri, File configDir) {
+    super(expectedDAO, configDir);
     bagSeqUri = bagIndexBaseUri.resolve("bag-sequence");
     this.bagStoreBaseUri = bagStoreBaseUri;
     this.bagIndexBaseUri = bagIndexBaseUri;

--- a/src/main/java/nl/knaw/dans/filemigration/core/VaultLoaderImpl.java
+++ b/src/main/java/nl/knaw/dans/filemigration/core/VaultLoaderImpl.java
@@ -19,12 +19,13 @@ import io.dropwizard.hibernate.UnitOfWork;
 import nl.knaw.dans.filemigration.api.ExpectedFile;
 import nl.knaw.dans.filemigration.db.ExpectedFileDAO;
 
+import java.io.File;
 import java.net.URI;
 
 public class VaultLoaderImpl extends VaultLoader {
 
-  public VaultLoaderImpl(ExpectedFileDAO expectedDAO, URI bagStoreBaseUri, URI bagIndexBaseUri) {
-    super(expectedDAO, bagStoreBaseUri, bagIndexBaseUri);
+  public VaultLoaderImpl(ExpectedFileDAO expectedDAO, URI bagStoreBaseUri, URI bagIndexBaseUri, File configDir) {
+    super(expectedDAO, bagStoreBaseUri, bagIndexBaseUri, configDir);
   }
 
   @UnitOfWork("hibernate")

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -24,6 +24,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,10 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
+import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class EasyFileLoaderTest {
@@ -44,7 +42,7 @@ public class EasyFileLoaderTest {
   private static class Loader extends EasyFileLoader {
 
     public Loader(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedDAO) {
-      super(easyFileDAO, expectedDAO, solrBaseUri());
+      super(easyFileDAO, expectedDAO, solrBaseUri(), new File("src/test/resources/debug-etc"));
     }
 
     @Override

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -24,7 +24,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
-import javax.validation.constraints.NotNull;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -35,6 +35,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
@@ -47,10 +48,12 @@ public class EasyFileLoaderTest {
     }
 
     @Override
-    protected @NotNull FileRights getDatasetRights(String datasetId) {
-      FileRights fileRights = new FileRights();
-      fileRights.setFileRights("NO_ACCESS");
-      return fileRights;
+    protected SolrFields getSolrFields(String datasetId) {
+      try {
+        return new SolrFields("2020-01-01,ANONYMOUS,somebody");
+      } catch (IOException e) {
+        return fail("Not expected exception on mocked test data");
+      }
     }
   }
 

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -177,8 +177,8 @@ public class EasyFileLoaderTest {
     for (String f : new String[] { "provenance.xml", "dataset.xml", "files.xml", "emd.xml" }) {
       ExpectedFile expectedFile = new ExpectedFile();
       expectedFile.setDoi(doi);
-      expectedFile.setExpected_path("easy-migration/" + f);
-      expectedFile.setAdded_during_migration(true);
+      expectedFile.setExpectedPath("easy-migration/" + f);
+      expectedFile.setAddedDuringMigration(true);
       expectedFiles.add(expectedFile);
       expectedFile.setAccessibleTo("NONE");
       expectedFile.setVisibleTo("NONE");

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
+  private static final String expectedSolr = "2016-11-11,\"no_ACCESS,accept,rechthebbende\",somebody";
 
   private static class Loader extends EasyFileLoader {
 
@@ -52,12 +53,8 @@ public class EasyFileLoaderTest {
     }
 
     @Override
-    protected SolrFields getSolrFields(String datasetId) {
-      try {
-        return new SolrFields("2020-01-01,OPEN_ACCESS,somebody");
-      } catch (IOException e) {
-        return fail("Not expected exception on mocked test data");
-      }
+    protected String rightsFromSolr(String datasetId) {
+        return expectedSolr;
     }
   }
 
@@ -80,7 +77,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, expectedFileDAO, easyFileDAO);
-    new Loader("", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -92,7 +89,7 @@ public class EasyFileLoaderTest {
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
     EasyFileDAO easyFileDAO = createMock(EasyFileDAO.class);
     replay(csv, expectedFileDAO, easyFileDAO);
-    new Loader("", null, null).loadFromCsv(csv);
+    new Loader(expectedSolr, null, null).loadFromCsv(csv);
     verify(csv, expectedFileDAO, easyFileDAO);
   }
 
@@ -106,7 +103,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -120,7 +117,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\"", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader("\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -140,7 +137,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -178,7 +175,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 

--- a/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/filemigration/core/EasyFileLoaderTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
-  private static final String expectedSolr = "2016-11-11,\"no_ACCESS,accept,rechthebbende\",somebody";
+  private static final String expectedSolr = "2016-11-11,\"OPEN_ACCESS,accept,rechthebbende\",somebody";
 
   private static class Loader extends EasyFileLoader {
 
@@ -157,7 +157,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("", easyFileDAO, expectedFileDAO).loadFromCsv(csv);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 

--- a/src/test/resources/debug-etc/account-substitutes.csv
+++ b/src/test/resources/debug-etc/account-substitutes.csv
@@ -1,0 +1,2 @@
+removed-account, chosen-account
+user001,USer


### PR DESCRIPTION
Fixes DD-566: add depositor/curator

# Description of changes

* applied camel/snake-case conventions, inconsistencies caused changes in columns names:
  * `accessibleTo` =>  `accessible_to` (tables actual and expected)
  * `visibleTo` =>  `visible_to` (table expected only)
* [x] new columns: `expected.depositor` and `actual.curator` filled by all three sub-commands
* [x] apply [easy-convert-bag-to-deposit/src/main/assembly/dist/cfg/account-substitutes.csv](https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/blob/master/src/main/assembly/dist/cfg/account-substitutes.csv)

**NB** the delivered CSV files causes an exception, add a record with the same value in both columns when no conversion is wanted.

# How to test

* `rm config.yml; start-preprovisioned-box.py -s dev_archaeology dev_vocabs deasy`
  deasy (and the vault?) can get in a corrupt state so you might have to remove deasy with all files in the VirtualBox gui
* build, deploy in dd-dtap:

      deploy.py -m dd-verify-file-migration dev_archaeology
      deploy.py -m dd-verify-file-migration deasy

* [x] in dd-dtap: `vagrant ssh dev_archaeology` 
  and`dd-verify-file-migration load-from-dataverse`
* [x] copy `src/test/resources/deasy.csv` to `dd-dtap/shared`, 
  in dd-dtap: `vagrant ssh deasy`,  add one row with identical values for both columns to
  `/etc/opt/dans.knaw.nl/dd-verify-file-migration/account-substitutes.csv`
  and `dd-verify-file-migration  load-from-fedora /vagrant/shared/deasy.csv`
  check the changes in the content of the table `actual`
* vault alias bag-store (_by the way: dev_vault_service has no need for dd-verify-file-migration_)
  * in easy-sword2-dans-examples: `./run.sh Simple https://deasy.dans.knaw.nl/sword2/collection/1 user001 user001 src/main/resources/agreement-flow/valid/XXX`
  * [x] in dd-dtap: `vagrant ssh dev_archaeology`, put the uuid of the deposit in `uuids.txt`
  and`dd-verify-file-migration load-from-vault  -u uuids.txt`

* [x] `anonymous` rights at file level should be overwritten with `known` rights at dataset level (fedora and vault)

# Related PRs
(Add links)
* requires for manual test on deasy: https://github.com/DANS-KNAW/dd-dtap/pull/209

# Notify
@DANS-KNAW/dataversedans
