### PR TITLE
DD-883: add license to dataset-metadata tables

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -30,6 +30,7 @@ dataverse:
 #
 
 solrBaseUri: 'http://localhost:8080/solr/'
+fedoraBaseUri: 'http://localhost:8080/fedora/'
 
 # null on a datastation (read system without easy_db)
 easyDb:

--- a/src/main/java/nl/knaw/dans/migration/DdVerifyMigrationConfiguration.java
+++ b/src/main/java/nl/knaw/dans/migration/DdVerifyMigrationConfiguration.java
@@ -44,6 +44,10 @@ public class DdVerifyMigrationConfiguration extends Configuration {
   private URI solrBaseUri;
 
   @Valid
+  @NotNull
+  private URI fedoraBaseUri;
+
+  @Valid
   @Nullable
   private DataSourceFactory easyDb = new DataSourceFactory();
 
@@ -99,5 +103,13 @@ public class DdVerifyMigrationConfiguration extends Configuration {
 
   public void setSolrBaseUri(URI solrBaseUri) {
     this.solrBaseUri = solrBaseUri;
+  }
+
+  public URI getFedoraBaseUri() {
+    return fedoraBaseUri;
+  }
+
+  public void setFedoraBaseUri(URI fedoraBaseUri) {
+    this.fedoraBaseUri = fedoraBaseUri;
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
@@ -93,12 +93,13 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
         EasyFileLoader proxy = new UnitOfWorkAwareProxyFactory(easyBundle, verificationBundle)
             .create(
                 EasyFileLoaderImpl.class,
-                new Class[] { EasyFileDAO.class, ExpectedFileDAO.class, ExpectedDatasetDAO.class, URI.class, File.class},
+                new Class[] { EasyFileDAO.class, ExpectedFileDAO.class, ExpectedDatasetDAO.class, URI.class, URI.class, File.class},
                 new Object[] {
                         new EasyFileDAO(easyBundle.getSessionFactory()),
                         new ExpectedFileDAO(verificationBundleSessionFactory),
                         new ExpectedDatasetDAO(verificationBundleSessionFactory),
                         configuration.getSolrBaseUri(),
+                        configuration.getFedoraBaseUri(),
                         new File(namespace.getString("file")).getParentFile(),
                 }
             );

--- a/src/main/java/nl/knaw/dans/migration/core/AccessCategory.java
+++ b/src/main/java/nl/knaw/dans/migration/core/AccessCategory.java
@@ -18,22 +18,31 @@ package nl.knaw.dans.migration.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static nl.knaw.dans.migration.core.DatasetLicenseHandler.cc0;
+import static nl.knaw.dans.migration.core.DatasetLicenseHandler.dansLicense;
+
 public enum AccessCategory {
 
-    OPEN_ACCESS("ANONYMOUS"),
-    OPEN_ACCESS_FOR_REGISTERED_USERS("KNOWN"),
-    REQUEST_PERMISSION("RESTRICTED_REQUEST"),
-    NO_ACCESS("NONE"),
-    GROUP_ACCESS("RESTRICTED_REQUEST");
+    OPEN_ACCESS("ANONYMOUS", cc0),
+    OPEN_ACCESS_FOR_REGISTERED_USERS("KNOWN", dansLicense),
+    REQUEST_PERMISSION("RESTRICTED_REQUEST", dansLicense),
+    NO_ACCESS("NONE", null),
+    GROUP_ACCESS("RESTRICTED_REQUEST", dansLicense);
     private static final Logger log = LoggerFactory.getLogger(AccessCategory.class);
 
     private final String fileRights;
+    private String defaultLicense;
 
-    AccessCategory(String fileRights) {
+    AccessCategory(String fileRights, String defaultLicense) {
         this.fileRights = fileRights;
+        this.defaultLicense = defaultLicense;
     }
 
     public String getFileRights() {
         return fileRights;
+    }
+
+    public String getDefaultLicense() {
+        return defaultLicense;
     }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
@@ -33,7 +33,7 @@ public class DatasetLicenseHandler extends DefaultHandler {
   private static final Logger log = LoggerFactory.getLogger(DatasetLicenseHandler.class);
 
   static final String dansLicense = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
-  static final String cc0 = "http://creativecommons.org/licenses/by-nc-sa/4.0/";
+  static final String cc0 = "http://creativecommons.org/licenses/by/4.0";
   private static final SAXParserFactory parserFactory = configureFactory();
   private StringBuilder chars; // collected since the last startElement
   private String license = null;
@@ -53,7 +53,9 @@ public class DatasetLicenseHandler extends DefaultHandler {
   public void endElement(String uri, String localName, String qName) {
 
     if ("license".equalsIgnoreCase(localName)) {
-      license = chars.toString();
+      String s = chars.toString();
+      if(s.startsWith("http"))
+        this.license = s;
     }
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.knaw.dans.migration.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+public class DatasetLicenseHandler extends DefaultHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(DatasetLicenseHandler.class);
+
+  static final String dansLicense = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
+  static final String cc0 = "http://creativecommons.org/licenses/by-nc-sa/4.0/";
+  private static final SAXParserFactory parserFactory = configureFactory();
+  private StringBuilder chars; // collected since the last startElement
+  private String license = null;
+
+  private static DatasetRights initDatasetRights() {
+    DatasetRights datasetRights = new DatasetRights();
+    datasetRights.setDefaultFileRights(new FileRights());
+    return datasetRights;
+  }
+
+  @Override
+  public void startElement(String uri, String localName, String qName, Attributes attributes) {
+    chars = new StringBuilder();
+  }
+
+  @Override
+  public void endElement(String uri, String localName, String qName) {
+
+    if ("license".equalsIgnoreCase(localName)) {
+      license = chars.toString();
+    }
+  }
+
+  @Override
+  public void characters(char[] ch, int start, int length) {
+    chars.append(new String(ch, start, length));
+  }
+
+  private String get() {
+    return license;
+  }
+
+  private static SAXParserFactory configureFactory() {
+    SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+    saxParserFactory.setNamespaceAware(true);
+    return saxParserFactory;
+  }
+
+  /**
+   * @return key: filepath attribute of file elements
+   * value: content of the elements: accessibleToRights and visibleToRights
+   */
+  static public String parseLicense(InputStream xml, AccessCategory accessCategory) {
+    DatasetLicenseHandler handler = new DatasetLicenseHandler();
+    try {
+      parserFactory.newSAXParser().parse(xml, handler);
+      return Optional.ofNullable(handler.get())
+          .orElse(accessCategory.getDefaultLicense());
+    }
+    catch (ParserConfigurationException | SAXException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
@@ -37,10 +37,9 @@ public class DatasetRights {
         this.defaultFileRights = defaultFileRights;
     }
 
-    public ExpectedDataset expectedDataset(String doi, String depositor) {
+    public ExpectedDataset expectedDataset(String depositor) {
         // TODO apply account-substitutes.csv to depositor
         ExpectedDataset expectedDataset = new ExpectedDataset();
-        expectedDataset.setDoi(doi);
         expectedDataset.setDepositor(depositor);
         expectedDataset.setAccessCategory(accessCategory);
         expectedDataset.setEmbargoDate(defaultFileRights);

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -100,6 +100,8 @@ public class DataverseLoader {
             ActualDataset actualDataset = new ActualDataset();
             actualDataset.setMajorVersionNr(v.getVersionNumber());
             actualDataset.setMinorVersionNr(v.getVersionMinorNumber());
+            actualDataset.setLicenseName(v.getLicense().getName());
+            actualDataset.setLicenseUri(v.getLicense().getUri().toString());
             actualDataset.setDoi(shortDoi);
             actualDataset.setDepositor(depositor);
             actualDataset.setFileAccessRequest(v.isFileAccessRequest());

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -102,7 +102,7 @@ public class DataverseLoader {
             actualDataset.setMinorVersionNr(v.getVersionMinorNumber());
             actualDataset.setDoi(shortDoi);
             actualDataset.setDepositor(depositor);
-            actualDataset.setAccessCategory("FileAccessRequest="+v.isFileAccessRequest());// TODO change table field?
+            actualDataset.setFileAccessRequest(v.isFileAccessRequest());
             saveActualDataset(actualDataset);
         }
     }

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoaderImpl.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoaderImpl.java
@@ -29,8 +29,8 @@ import java.util.List;
 
 public class EasyFileLoaderImpl extends EasyFileLoader {
 
-    public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedFileDAO, ExpectedDatasetDAO expectedDatasetDAO, URI solrBaseUri, File configDir) {
-        super(easyFileDAO, expectedFileDAO, expectedDatasetDAO, solrBaseUri, configDir);
+    public EasyFileLoaderImpl(EasyFileDAO easyFileDAO, ExpectedFileDAO expectedFileDAO, ExpectedDatasetDAO expectedDatasetDAO, URI solrBaseUri, URI fedoraBaseUri, File configDir) {
+        super(easyFileDAO, expectedFileDAO, expectedDatasetDAO, solrBaseUri, fedoraBaseUri, configDir);
     }
 
   @UnitOfWork("easyBundle")

--- a/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
@@ -67,14 +67,6 @@ public class SolrFields {
         }
     }
 
-    public String getCreator() {
-        return creator;
-    }
-
-    public AccessCategory getAccessCategory() {
-        return accessCategory;
-    }
-
     public DatasetRights datasetRights() {
         FileRights rights = new FileRights();
         rights.setFileRights(accessCategory);

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -58,12 +58,15 @@ public class VaultLoader extends ExpectedLoader {
   private final URI bagIndexBaseUri;
   private final URI bagSeqUri;
   private final ObjectMapper mapper;
+  private final Map<String, String> accountSubStitues;
 
   public VaultLoader(ExpectedFileDAO expectedFileDAO, ExpectedDatasetDAO expectedDatasetDAO, URI bagStoreBaseUri, URI bagIndexBaseUri, File configDir) {
     super(expectedFileDAO, expectedDatasetDAO, configDir);
     bagSeqUri = bagIndexBaseUri.resolve("bag-sequence");
     this.bagStoreBaseUri = bagStoreBaseUri;
     this.bagIndexBaseUri = bagIndexBaseUri;
+    this.accountSubStitues = Accounts.load(configDir);
+
 
     mapper = new ObjectMapper();
     SimpleModule module = new SimpleModule();
@@ -111,7 +114,8 @@ public class VaultLoader extends ExpectedLoader {
             createExpected(doi, m, filesXml, datasetRights.defaultFileRights)
     );
     expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
-    ExpectedDataset expectedDataset = datasetRights.expectedDataset(readDepositor(uuid));
+    String depositor = readDepositor(uuid);
+    ExpectedDataset expectedDataset = datasetRights.expectedDataset(accountSubStitues.getOrDefault(depositor, depositor));
     expectedDataset.setDoi(doi);
     expectedDataset.setLicense(DatasetLicenseHandler.parseLicense(new ByteArrayInputStream(ddmBytes),datasetRights.accessCategory));
     saveExpectedDataset(expectedDataset);

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -24,6 +24,7 @@ import nl.knaw.dans.lib.dataverse.ResultItemDeserializer;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
+import nl.knaw.dans.migration.core.tables.ExpectedDataset;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
@@ -104,11 +105,14 @@ public class VaultLoader extends ExpectedLoader {
   private void processBag(String uuid, BagInfo bagInfo) {
     Map<String, FileRights> filesXml = readFileMeta(uuid);
     DatasetRights datasetRights = readDDM(uuid);
+    String doi = bagInfo.getDoi();
     readManifest(uuid).forEach(m ->
-            createExpected(bagInfo.getDoi(), m, filesXml, datasetRights.defaultFileRights)
+            createExpected(doi, m, filesXml, datasetRights.defaultFileRights)
     );
-    expectedMigrationFiles(bagInfo.getDoi(), migrationFiles, datasetRights.defaultFileRights);
-    saveExpectedDataset(datasetRights.expectedDataset(bagInfo.getDoi(),readDepositor(uuid)));
+    expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
+    ExpectedDataset expectedDataset = datasetRights.expectedDataset(readDepositor(uuid));
+    expectedDataset.setDoi(doi);
+    saveExpectedDataset(expectedDataset);
   }
 
   private void createExpected(String doi, ManifestCsv m, Map<String, FileRights> fileRightsMap, FileRights defaultFileRights) {

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
@@ -45,7 +45,7 @@ public class ActualDataset {
   private int minorVersionNr;
 
   @Column(name="access_category")
-  private String accessCategory;
+  private boolean fileAccessRequest;
 
   @Nullable
   @Column(name="depositor")
@@ -75,12 +75,12 @@ public class ActualDataset {
     this.minorVersionNr = minorVersionNr;
   }
 
-  public String getAccessCategory() {
-    return accessCategory;
+  public boolean isFileAccessRequest() {
+    return fileAccessRequest;
   }
 
-  public void setAccessCategory(String accessCategory) {
-    this.accessCategory = accessCategory;
+  public void setFileAccessRequest(boolean fileAccessRequest) {
+    this.fileAccessRequest = fileAccessRequest;
   }
 
   @Nullable
@@ -98,7 +98,7 @@ public class ActualDataset {
             "doi='" + doi + '\'' +
             ", majorVersionNr=" + majorVersionNr +
             ", minorVersionNr=" + minorVersionNr +
-            ", accessCategory='" + accessCategory + '\'' +
+            ", accessCategory='" + fileAccessRequest + '\'' +
             ", depositor='" + depositor + '\'' +
             '}';
   }
@@ -108,11 +108,11 @@ public class ActualDataset {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ActualDataset that = (ActualDataset) o;
-    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(fileAccessRequest, that.fileAccessRequest) && Objects.equals(depositor, that.depositor);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, majorVersionNr, minorVersionNr, accessCategory, depositor);
+    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, depositor);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
@@ -47,6 +47,12 @@ public class ActualDataset {
   @Column(name="access_category")
   private boolean fileAccessRequest;
 
+  @Column(name="license_name")
+  private String licenseName;
+
+  @Column(name="license_url")
+  private String licenseUri;
+
   @Nullable
   @Column(name="depositor")
   private String depositor;
@@ -83,6 +89,22 @@ public class ActualDataset {
     this.fileAccessRequest = fileAccessRequest;
   }
 
+  public String getLicenseName() {
+    return licenseName;
+  }
+
+  public void setLicenseName(String licenseName) {
+    this.licenseName = licenseName;
+  }
+
+  public String getLicenseUri() {
+    return licenseUri;
+  }
+
+  public void setLicenseUri(String licenseUri) {
+    this.licenseUri = licenseUri;
+  }
+
   @Nullable
   public String getDepositor() {
     return depositor;
@@ -95,24 +117,29 @@ public class ActualDataset {
   @Override
   public String toString() {
     return "ActualDataset{" +
-            "doi='" + doi + '\'' +
-            ", majorVersionNr=" + majorVersionNr +
-            ", minorVersionNr=" + minorVersionNr +
-            ", accessCategory='" + fileAccessRequest + '\'' +
-            ", depositor='" + depositor + '\'' +
-            '}';
+        "doi='" + doi + '\'' +
+        ", majorVersionNr=" + majorVersionNr +
+        ", minorVersionNr=" + minorVersionNr +
+        ", fileAccessRequest=" + fileAccessRequest +
+        ", licenseName='" + licenseName + '\'' +
+        ", licenseUrl='" + licenseUri + '\'' +
+        ", depositor='" + depositor + '\'' +
+        '}';
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
     ActualDataset that = (ActualDataset) o;
-    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && Objects.equals(doi, that.doi) && Objects.equals(fileAccessRequest, that.fileAccessRequest) && Objects.equals(depositor, that.depositor);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && fileAccessRequest == that.fileAccessRequest && Objects.equals(doi, that.doi)
+        && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUri, that.licenseUri) && Objects.equals(depositor, that.depositor);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, depositor);
+    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, licenseName, licenseUri, depositor);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -46,6 +46,10 @@ public class ExpectedDataset {
     @Column(name="embargo_date")
     private String embargoDate;
 
+    @Nullable
+    @Column(name="license")
+    private String license;
+
     @Column(name = "depositor")
     private String depositor;
 
@@ -83,26 +87,39 @@ public class ExpectedDataset {
         this.depositor = depositor;
     }
 
+    @Nullable
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(@Nullable String license) {
+        this.license = license;
+    }
+
     @Override
     public String toString() {
         return "ExpectedDataset{" +
-                "doi='" + doi + '\'' +
-                ", accessCategory='" + accessCategory + '\'' +
-                ", embargoDate='" + embargoDate + '\'' +
-                ", depositor='" + depositor + '\'' +
-                '}';
+            "doi='" + doi + '\'' +
+            ", accessCategory='" + accessCategory + '\'' +
+            ", embargoDate='" + embargoDate + '\'' +
+            ", license='" + license + '\'' +
+            ", depositor='" + depositor + '\'' +
+            '}';
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         ExpectedDataset that = (ExpectedDataset) o;
-        return Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(depositor, that.depositor);
+        return Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(embargoDate, that.embargoDate)
+            && Objects.equals(license, that.license) && Objects.equals(depositor, that.depositor);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, accessCategory, embargoDate, depositor);
+        return Objects.hash(doi, accessCategory, embargoDate, license, depositor);
     }
 }

--- a/src/test/java/nl/knaw/dans/migration/core/DatasetLicenseHandlerTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/DatasetLicenseHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.migration.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DatasetLicenseHandlerTest {
+
+    @Test
+    public void parseDD_874() throws IOException {
+        String license = DatasetLicenseHandler
+            .parseLicense(new FileInputStream("src/test/resources/ddm/DD-874.xml"), AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
+        assertEquals(DatasetLicenseHandler.cc0, license);
+    }
+
+    @Test
+    public void defaultCC0() {
+        String license = DatasetLicenseHandler
+            .parseLicense(new ByteArrayInputStream("<emd></emd>".getBytes(StandardCharsets.UTF_8)), AccessCategory.OPEN_ACCESS);
+        assertEquals(DatasetLicenseHandler.cc0, license);
+    }
+
+    @Test
+    public void defaultDans() {
+        ByteArrayInputStream ddmIS = new ByteArrayInputStream("<emd></emd>".getBytes(StandardCharsets.UTF_8));
+        String license = DatasetLicenseHandler.parseLicense(ddmIS, AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
+        assertEquals(DatasetLicenseHandler.dansLicense, license);
+    }
+
+    @Test
+    public void defaultNone() {
+        String ddm = "<emd xmlns:dct=\"http://purl.org/dc/terms/\"><dct:license>accept</dct:license></emd>";
+        String license = DatasetLicenseHandler
+            .parseLicense(new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8)), AccessCategory.NO_ACCESS);
+        assertNull(license);
+    }
+
+    @Test
+    public void alsoForDdm() {
+        String start = "<ddm:DDM xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">";
+        String ddm = start + "<ddm:dcmiMetadata><dcterms:license xsi:type=\"dcterms:URI\">http://opensource.org/licenses/MIT</dcterms:license></ddm:dcmiMetadata></ddm:DDM>";
+        String license = DatasetLicenseHandler
+            .parseLicense(new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8)), AccessCategory.NO_ACCESS);
+        assertEquals("http://opensource.org/licenses/MIT", license);
+    }
+}

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -29,6 +29,7 @@ import javax.persistence.PersistenceException;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,7 +48,7 @@ public class EasyFileLoaderTest {
 
     private final String expectedSolr;
     public Loader(String expectedSolr, EasyFileDAO easyFileDAO, ExpectedFileDAO expectedFileDAO, ExpectedDatasetDAO expectedDatasetDAO) {
-      super(easyFileDAO, expectedFileDAO, expectedDatasetDAO, solrBaseUri(), new File("src/test/resources/debug-etc"));
+      super(easyFileDAO, expectedFileDAO, expectedDatasetDAO, dummyBaseUri(), dummyBaseUri(), new File("src/test/resources/debug-etc"));
       this.expectedSolr = expectedSolr;
     }
 
@@ -56,7 +57,12 @@ public class EasyFileLoaderTest {
       return expectedSolr;
     }
 
-    static URI solrBaseUri(){
+    @Override
+    protected String readEmd(String datasetId) {
+      return "<ddm><license>blabla</license></ddm>";
+    }
+
+    static URI dummyBaseUri(){
       try {
         return new URI("http://does.not.exist.dans.knaw.nl:8080/solr/");
       } catch (URISyntaxException e) {

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -49,7 +49,7 @@ easyDb:
     hibernate.hbm2ddl.auto: update
 
 solrBaseUri: 'http://deasy.dans.knaw.nl:8080/solr'
-
+  localhost
 verificationDatabase:
   driverClass: org.hsqldb.jdbcDriver
   url: 'jdbc:hsqldb:hsql://localhost:9001/verificationDatabase'


### PR DESCRIPTION
Fixes DD-883: add license to dataset-metadata tables

## NB commit typo: `emails for dataverse from easy-users.csv` should be `emails for vault from easy-users.csv`

# Description of changes
* license URI from EMD fedora stream for load-from-fedora as far as the content starts with http
* license URI from dataset.xml for load-from-vault as far as the content starts with http
* license name+URI from dataset-version for load-from-vault


# How to test

More or less as in https://github.com/DANS-KNAW/dd-verify-migration/pull/10 note that the project has been renamed
* [x] load-from-fedora looks OK
* [x] load-from-vault requires the depositor(s) of the bags in the store
  in `/etc/opt/dans.knaw.nl/dd-verify-migration/easy-users.csv`
  delivered is only a `user001` for (some?) deasy fedora datasets
* [x] load-from-datavers


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
