### PR TITLE
DD-882: register deleted datasets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.0.11</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
@@ -71,7 +71,6 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
 
     @Override
     protected void run(Bootstrap<DdVerifyMigrationConfiguration> bootstrap, Namespace namespace, DdVerifyMigrationConfiguration configuration) throws Exception {
-        // TODO move up to DefaultConfigEnvironmentCommand in dans-java-utils with generic <T> ?
         initialize(bootstrap, namespace, configuration);
         // super calls (among others)
         // - bundle.run for all bootstrap.configuredBundles (via bootstrap.run)
@@ -81,6 +80,7 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
     }
 
     public void initialize(Bootstrap<DdVerifyMigrationConfiguration> bootstrap, Namespace namespace, DdVerifyMigrationConfiguration configuration) throws Exception {
+        // The application class only adds bundles to bootstrap that are required by all commands
         if (configuration.getEasyDb() == null)
             throw new ConfigurationException(getName() + " requires easyDb parameters in " + namespace.get("file"));
         bootstrap.addBundle(easyBundle);

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
@@ -38,7 +38,7 @@ public class DatasetRights {
     }
 
     public ExpectedDataset expectedDataset(String depositor) {
-        // TODO apply account-substitutes.csv to depositor
+        // ExpectedLoader.saveExpectedDataset applies account-substitutes.csv to depositor
         ExpectedDataset expectedDataset = new ExpectedDataset();
         expectedDataset.setDepositor(depositor);
         expectedDataset.setAccessCategory(accessCategory);

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -100,6 +100,7 @@ public class DataverseLoader {
             ActualDataset actualDataset = new ActualDataset();
             actualDataset.setMajorVersionNr(v.getVersionNumber());
             actualDataset.setMinorVersionNr(v.getVersionMinorNumber());
+            actualDataset.setDeaccessioned("DEACCESSIONED".equals(v.getVersionState()));
             actualDataset.setLicenseName(v.getLicense().getName());
             actualDataset.setLicenseUri(v.getLicense().getUri().toString());
             actualDataset.setDoi(shortDoi);

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -63,6 +63,7 @@ public class EasyFileLoader extends ExpectedLoader {
       DatasetRights datasetRights = solrFields.datasetRights();
       ExpectedDataset expected = datasetRights.expectedDataset(solrFields.creator);
       expected.setDoi(csv.getDoi());
+      expected.setDeleted("DELETED".equals(solrFields.state));
       if (!AccessCategory.NO_ACCESS.equals(solrFields.accessCategory)) {
         byte[] emdBytes = readEmd(csv.getDatasetId())
             .getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/nl/knaw/dans/migration/core/HttpHelper.java
+++ b/src/main/java/nl/knaw/dans/migration/core/HttpHelper.java
@@ -38,6 +38,11 @@ public class HttpHelper {
                 log.error("Could not find {}", req.getURI());
             return "";
         }
+        if (statusCode == 410) {
+            if (logNotFound)
+                log.error("Deactivated {}", req.getURI());
+            return "";
+        }
         else if (statusCode < 200 || statusCode >= 300)
             throw new IOException("not expected response code: " + statusCode);
         else

--- a/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
@@ -45,7 +45,6 @@ public class SolrFields {
                 .replaceAll("^\"", "") // strip leading quote
                 .replaceAll("\"$", "") // strip trailing quote
                 .split(", *");
-        // TODO parseHeadlessCsvLine(dcRecord).getRecords().get(0).iterator();
         Optional<AccessCategory> maybeRights= Arrays.stream(dcRights)
                 .filter(this::isDatasetRights)
                 .map(AccessCategory::valueOf)

--- a/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
@@ -31,16 +31,19 @@ public class SolrFields {
 
     private static final Logger log = LoggerFactory.getLogger(EasyFileLoader.class);
 
-    public static String requestedFields = "emd_date_available_formatted,dc_rights,amd_depositor_id";
+    public static String requestedFields = "emd_date_available_formatted,dc_rights,amd_depositor_id,ds_state";
     private static final CSVFormat solrFormat = CSVFormat.RFC4180.withDelimiter(',');
     final String available;
     final String creator;
     final AccessCategory accessCategory;
+    final String state;
+
     SolrFields (String line) throws IOException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8));
         CSVRecord record = CSVParser.parse(inputStream, StandardCharsets.UTF_8, solrFormat).getRecords().get(0);
         available = record.get(0).trim();
         creator = record.get(2).trim();
+        state = record.get(3).trim();
         String[] dcRights = record.get(1).trim()
                 .replaceAll("^\"", "") // strip leading quote
                 .replaceAll("\"$", "") // strip trailing quote

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -86,7 +86,7 @@ public class VaultLoader extends ExpectedLoader {
     else {
       log.trace("Processing {}", bagInfo);
       String[] bagSeq = readBagSequence(uuid);
-      if (bagSeq.length == 0)
+      if (bagSeq.length <= 1)
         processBag(uuid.toString(), bagInfo);
       else {
         List<BagInfo> bagInfos= StreamSupport
@@ -106,18 +106,20 @@ public class VaultLoader extends ExpectedLoader {
   private static final String[] migrationFiles = { "provenance.xml", "dataset.xml", "files.xml" };
 
   private void processBag(String uuid, BagInfo bagInfo) {
-    Map<String, FileRights> filesXml = readFileMeta(uuid);
-    byte[] ddmBytes = readDDM(uuid).getBytes(StandardCharsets.UTF_8);// parsed twice to reuse code shared with EasyFileLoader
-    DatasetRights datasetRights = DatasetRightsHandler.parseRights(new ByteArrayInputStream(ddmBytes));
     String doi = bagInfo.getDoi();
-    readManifest(uuid).forEach(m ->
-            createExpected(doi, m, filesXml, datasetRights.defaultFileRights)
-    );
-    expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
+    byte[] ddmBytes = readDDM(uuid).getBytes(StandardCharsets.UTF_8);// parsed twice to reuse code shared with EasyFileLoader
+    if (ddmBytes.length == 0) return; // not found or deactivated has been logged
+    DatasetRights datasetRights = DatasetRightsHandler.parseRights(new ByteArrayInputStream(ddmBytes));
     String depositor = readDepositor(uuid);
     ExpectedDataset expectedDataset = datasetRights.expectedDataset(accountSubStitues.getOrDefault(depositor, depositor));
     expectedDataset.setDoi(doi);
     expectedDataset.setLicense(DatasetLicenseHandler.parseLicense(new ByteArrayInputStream(ddmBytes),datasetRights.accessCategory));
+    // now that we collected everything from the bag, we start processing the files
+    Map<String, FileRights> filesXml = readFileMeta(uuid);
+    readManifest(uuid).forEach(m ->
+        createExpected(doi, m, filesXml, datasetRights.defaultFileRights)
+    );
+    expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
     saveExpectedDataset(expectedDataset);
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
@@ -44,8 +44,11 @@ public class ActualDataset {
   @Column(name="minor_version_nr")
   private int minorVersionNr;
 
-  @Column(name="access_category")
+  @Column(name="file_access_request")
   private boolean fileAccessRequest;
+
+  @Column(name="deaccessioned")
+  private boolean deaccessioned;
 
   @Column(name="license_name")
   private String licenseName;
@@ -89,6 +92,14 @@ public class ActualDataset {
     this.fileAccessRequest = fileAccessRequest;
   }
 
+  public boolean isDeaccessioned() {
+    return deaccessioned;
+  }
+
+  public void setDeaccessioned(boolean deaccessioned) {
+    this.deaccessioned = deaccessioned;
+  }
+
   public String getLicenseName() {
     return licenseName;
   }
@@ -121,8 +132,9 @@ public class ActualDataset {
         ", majorVersionNr=" + majorVersionNr +
         ", minorVersionNr=" + minorVersionNr +
         ", fileAccessRequest=" + fileAccessRequest +
+        ", deaccessioned=" + deaccessioned +
         ", licenseName='" + licenseName + '\'' +
-        ", licenseUrl='" + licenseUri + '\'' +
+        ", licenseUri='" + licenseUri + '\'' +
         ", depositor='" + depositor + '\'' +
         '}';
   }
@@ -134,12 +146,13 @@ public class ActualDataset {
     if (o == null || getClass() != o.getClass())
       return false;
     ActualDataset that = (ActualDataset) o;
-    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && fileAccessRequest == that.fileAccessRequest && Objects.equals(doi, that.doi)
-        && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUri, that.licenseUri) && Objects.equals(depositor, that.depositor);
+    return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && fileAccessRequest == that.fileAccessRequest && deaccessioned == that.deaccessioned
+        && Objects.equals(doi, that.doi) && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUri, that.licenseUri) && Objects.equals(
+        depositor, that.depositor);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, licenseName, licenseUri, depositor);
+    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, deaccessioned, licenseName, licenseUri, depositor);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -50,7 +50,6 @@ public class ExpectedDataset {
     @Column(name="license")
     private String license;
 
-    @Nullable
     @Column(name="deleted")
     private boolean deleted;
 
@@ -100,12 +99,11 @@ public class ExpectedDataset {
         this.license = license;
     }
 
-    @Nullable
     public boolean getDeleted() {
         return deleted;
     }
 
-    public void setDeleted(@Nullable boolean deleted) {
+    public void setDeleted(boolean deleted) {
         this.deleted = deleted;
     }
 

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -50,6 +50,10 @@ public class ExpectedDataset {
     @Column(name="license")
     private String license;
 
+    @Nullable
+    @Column(name="deleted")
+    private boolean deleted;
+
     @Column(name = "depositor")
     private String depositor;
 
@@ -96,6 +100,15 @@ public class ExpectedDataset {
         this.license = license;
     }
 
+    @Nullable
+    public boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(@Nullable boolean deleted) {
+        this.deleted = deleted;
+    }
+
     @Override
     public String toString() {
         return "ExpectedDataset{" +
@@ -103,6 +116,7 @@ public class ExpectedDataset {
             ", accessCategory='" + accessCategory + '\'' +
             ", embargoDate='" + embargoDate + '\'' +
             ", license='" + license + '\'' +
+            ", deleted='" + deleted + '\'' +
             ", depositor='" + depositor + '\'' +
             '}';
     }
@@ -115,11 +129,11 @@ public class ExpectedDataset {
             return false;
         ExpectedDataset that = (ExpectedDataset) o;
         return Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(embargoDate, that.embargoDate)
-            && Objects.equals(license, that.license) && Objects.equals(depositor, that.depositor);
+            && Objects.equals(license, that.license) && Objects.equals(deleted, that.deleted) && Objects.equals(depositor, that.depositor);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, accessCategory, embargoDate, license, depositor);
+        return Objects.hash(doi, accessCategory, embargoDate, license, deleted, depositor);
     }
 }

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -42,7 +42,7 @@ import static org.easymock.EasyMock.verify;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
-  private static final String expectedSolr = "2022-03-08," + AccessCategory.NO_ACCESS + ",somebody";
+  private static final String expectedSolr = "2022-03-08," + AccessCategory.NO_ACCESS + ",somebody,PUBLISHED";
 
   private static class Loader extends EasyFileLoader {
 
@@ -127,7 +127,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
+    new Loader("\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody,PUBLISHED", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -141,7 +141,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("2009-06-04,\"RAAP Archeologisch Adviesbureau,GROUP_ACCESS\",somebody", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
+    new Loader("2009-06-04,\"RAAP Archeologisch Adviesbureau,GROUP_ACCESS\",somebody,PUBLISHED", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 

--- a/src/test/resources/deaccessioned.json
+++ b/src/test/resources/deaccessioned.json
@@ -1,0 +1,225 @@
+{
+  "status": "OK",
+  "data": [
+    {
+      "id": 1,
+      "datasetId": 2,
+      "datasetPersistentId": "doi:10.5072/DAR/PISP8Z",
+      "storageIdentifier": "file://10.5072/DAR/PISP8Z",
+      "versionNumber": 1,
+      "versionMinorNumber": 0,
+      "versionState": "DEACCESSIONED",
+      "versionNote": "test",
+      "lastUpdateTime": "2022-03-22T12:20:08Z",
+      "releaseTime": "2022-03-22T12:20:08Z",
+      "createTime": "2022-03-22T12:19:52Z",
+      "license": {
+        "name": "CC0 1.0",
+        "uri": "http://creativecommons.org/publicdomain/zero/1.0"
+      },
+      "fileAccessRequest": false,
+      "metadataBlocks": {
+        "citation": {
+          "displayName": "Citation Metadata",
+          "name": "citation",
+          "fields": [
+            {
+              "typeName": "title",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "blas"
+            },
+            {
+              "typeName": "author",
+              "multiple": true,
+              "typeClass": "compound",
+              "value": [
+                {
+                  "authorName": {
+                    "typeName": "authorName",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "User01, Test01"
+                  },
+                  "authorAffiliation": {
+                    "typeName": "authorAffiliation",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "DANS"
+                  }
+                }
+              ]
+            },
+            {
+              "typeName": "datasetContact",
+              "multiple": true,
+              "typeClass": "compound",
+              "value": [
+                {
+                  "datasetContactName": {
+                    "typeName": "datasetContactName",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "User01, Test01"
+                  },
+                  "datasetContactAffiliation": {
+                    "typeName": "datasetContactAffiliation",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "DANS"
+                  }
+                }
+              ]
+            },
+            {
+              "typeName": "dsDescription",
+              "multiple": true,
+              "typeClass": "compound",
+              "value": [
+                {
+                  "dsDescriptionValue": {
+                    "typeName": "dsDescriptionValue",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "sah"
+                  }
+                },
+                {
+                  "dsDescriptionValue": {
+                    "typeName": "dsDescriptionValue",
+                    "multiple": false,
+                    "typeClass": "primitive",
+                    "value": "A copy of this dataset is stored in EASY, the DANS CTS certified repository, at <a href=\"http://www.persistent-identifier.nl?identifier=urn:nbn:nl:ui:13-77f15f74-a15b-4c97-add5-d854ff459c43\">urn:nbn:nl:ui:13-77f15f74-a15b-4c97-add5-d854ff459c43</a>. (Note that this link will become resolvable only after the mirroring process has finished, which will take up to several days after first publication of the dataset.)<input type=\"hidden\" value=\"NBN\"></input>"
+                  }
+                }
+              ]
+            },
+            {
+              "typeName": "subject",
+              "multiple": true,
+              "typeClass": "controlledVocabulary",
+              "value": [
+                "Agricultural Sciences"
+              ]
+            },
+            {
+              "typeName": "depositor",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "User01, Test01"
+            },
+            {
+              "typeName": "dateOfDeposit",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "2022-03-22"
+            }
+          ]
+        },
+        "dansRights": {
+          "displayName": "Rights Metadata",
+          "name": "dansRights",
+          "fields": [
+            {
+              "typeName": "dansRightsHolder",
+              "multiple": true,
+              "typeClass": "primitive",
+              "value": [
+                "me"
+              ]
+            },
+            {
+              "typeName": "dansPersonalDataPresent",
+              "multiple": false,
+              "typeClass": "controlledVocabulary",
+              "value": "No"
+            }
+          ]
+        },
+        "dansRelationMetadata": {
+          "displayName": "Relation Metadata",
+          "name": "dansRelationMetadata",
+          "fields": [
+            {
+              "typeName": "dansAudience",
+              "multiple": true,
+              "typeClass": "primitive",
+              "value": [
+                "https://www.narcis.nl/classification/D23360"
+              ],
+              "expandedvalue": [
+                {
+                  "@id": "https://www.narcis.nl/classification/D23360",
+                  "termName": [
+                    {
+                      "lang": "nl",
+                      "value": "Leeftijdgebonden specialismen"
+                    },
+                    {
+                      "lang": "en",
+                      "value": "Age-related medical specialisms"
+                    }
+                  ],
+                  "vocabularyUri": "https://www.narcis.nl/classification/"
+                }
+              ]
+            }
+          ]
+        },
+        "dansDataVaultMetadata": {
+          "displayName": "Data Vault Metadata",
+          "name": "dansDataVaultMetadata",
+          "fields": [
+            {
+              "typeName": "dansDataversePid",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "doi:10.5072/DAR/PISP8Z"
+            },
+            {
+              "typeName": "dansDataversePidVersion",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "1.0"
+            },
+            {
+              "typeName": "dansBagId",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "urn:uuid:b3210282-4a79-46f2-ab15-1402e6e8bdc7"
+            },
+            {
+              "typeName": "dansNbn",
+              "multiple": false,
+              "typeClass": "primitive",
+              "value": "urn:nbn:nl:ui:13-77f15f74-a15b-4c97-add5-d854ff459c43"
+            }
+          ]
+        }
+      },
+      "files": [
+        {
+          "label": "Screenshot 2022-03-13 at 15.49.29.png",
+          "restricted": false,
+          "version": 1,
+          "datasetVersionId": 1,
+          "dataFile": {
+            "id": 3,
+            "persistentId": "",
+            "pidURL": "",
+            "filename": "Screenshot 2022-03-13 at 15.49.29.png",
+            "contentType": "image/png",
+            "filesize": 193417,
+            "storageIdentifier": "file://17fb1917b62-c0f5b5500bb1",
+            "rootDataFileId": -1,
+            "checksum": {
+              "type": "SHA-1",
+              "value": "ffd6367ccc699d21437254094a2f698dab69251b"
+            },
+            "creationDate": "2022-03-22"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes DD-882: register deleted datasets

# Description of changes

Bags deleted from the bag-store will produce no more than a tomb-stone (a doi and deleted=true) expected_files will contain nothing for delete bags.

Deleted fedora datasets and deaccessioned dataverse datasets will produce as many details as not deleted ones.

# How to test
* [x] load-from-dataverse
  * make sure to have published and deaccessioned datasets on dar
  * build deploy on dar and run without further arguments
* [x] load-from-fedora
  * login as admin on the deasy ui, delete a dataset
  * on deasy run `easy-update-solr-index 'easy-dataset:15'` or which ever dataset you deleted
  * run with trailing argument `fedora-to-bag.csv` with at least the deleted dataset in the input
* [x] load-from-vault (alias bag-store) not yet implemented,
   can't read files (files.xml, dataset.xml, manifest-sha1.txt, bag-info.txt) of these datasets with the easy-bag-store API
  * in easy-sword2-dans-examples: `./run.sh Simple https://deasy.dans.knaw.nl/sword2/collection/1 user001 user001 src/main/resources/agreement-flow/valid/XXX`
  * on deasy with one of the UUIDs of the previous command

        sudo su easy-bag-store
        easy-bag-store -s easy deactivate <bag-id>

  * run with argument `-u uuids.txt` containing the UUIDS of the loaded example bags

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
