### PR TITLE
DD-919: add citation year to dataset metadata

### DIFF
--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignmentReadOnly;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
+import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.file.DataFile;
 import nl.knaw.dans.lib.dataverse.model.file.Embargo;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
@@ -106,6 +107,11 @@ public class DataverseLoader {
             actualDataset.setDoi(shortDoi);
             actualDataset.setDepositor(depositor);
             actualDataset.setFileAccessRequest(v.isFileAccessRequest());
+            v.getMetadataBlocks()
+                .get("citation").getFields().stream()
+                .filter(field -> "dateOfDeposit".equals(field.getTypeName()))
+                .map(field -> ((PrimitiveSingleValueField)field).getValue())
+                .forEach(date -> log.trace("date in citation-block: " + date.substring(0,4))); // TODO assign
             saveActualDataset(actualDataset);
         }
     }

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -91,6 +91,7 @@ public class DataverseLoader {
             return;
         }
         String shortDoi = doi.replace("doi:", "");
+        DatasetVersion lastVersion = versions.get(versions.size() - 1);
         for (DatasetVersion v : versions) {
             int fileCount = 0;
             for (FileMeta f : v.getFiles()) {
@@ -106,7 +107,7 @@ public class DataverseLoader {
             actualDataset.setLicenseUri(v.getLicense().getUri().toString());
             actualDataset.setDoi(shortDoi);
             actualDataset.setDepositor(depositor);
-            actualDataset.setFileAccessRequest(v.isFileAccessRequest());
+            actualDataset.setFileAccessRequest(lastVersion.isFileAccessRequest());
             v.getMetadataBlocks()
                 .get("citation").getFields().stream()
                 .filter(field -> "dateOfDeposit".equals(field.getTypeName()))

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -111,7 +111,7 @@ public class DataverseLoader {
                 .get("citation").getFields().stream()
                 .filter(field -> "dateOfDeposit".equals(field.getTypeName()))
                 .map(field -> ((PrimitiveSingleValueField)field).getValue())
-                .forEach(date -> log.trace("date in citation-block: " + date.substring(0,4))); // TODO assign
+                .forEach(date -> actualDataset.setCitationYear(date.substring(0,4)));
             saveActualDataset(actualDataset);
         }
     }

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -63,6 +63,7 @@ public class EasyFileLoader extends ExpectedLoader {
       DatasetRights datasetRights = solrFields.datasetRights();
       ExpectedDataset expected = datasetRights.expectedDataset(solrFields.creator);
       expected.setDoi(csv.getDoi());
+      expected.setCitationYear(solrFields.date);
       expected.setDeleted("DELETED".equals(solrFields.state));
       if (!AccessCategory.NO_ACCESS.equals(solrFields.accessCategory)) {
         byte[] emdBytes = readEmd(csv.getDatasetId())

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -76,6 +76,7 @@ public class EasyFileLoader extends ExpectedLoader {
         fedoraFiles(csv, datasetRights.defaultFileRights);
       }
       expectedMigrationFiles(csv.getDoi(), migrationFiles, datasetRights.defaultFileRights);
+      log.trace("solr.emd_date_created_formatted: " + solrFields.date.substring(0,4));
       saveExpectedDataset(expected);
     } catch (IOException | URISyntaxException e) {
       // expecting an empty line when not found, other errors are fatal

--- a/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
@@ -54,6 +54,7 @@ public class ExpectedLoader {
       expectedFile.setRemovedDuplicateFileCount(0);
       expectedFile.setTransformedName(false);
       expectedFile.setDefaultRights(datasetRights);
+      expectedFile.setVisibleTo("ANONYMOUS");
       retriedSave(expectedFile);
     }
   }

--- a/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
@@ -53,8 +53,8 @@ public class ExpectedLoader {
       expectedFile.setRemovedOriginalDirectory(false);
       expectedFile.setRemovedDuplicateFileCount(0);
       expectedFile.setTransformedName(false);
-      expectedFile.setDefaultRights(datasetRights);
       expectedFile.setVisibleTo("ANONYMOUS");
+      expectedFile.setAccessibleTo("ANONYMOUS");
       retriedSave(expectedFile);
     }
   }

--- a/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
@@ -45,7 +45,7 @@ public class SolrFields {
         available = record.get(0).trim();
         creator = record.get(2).trim();
         state = record.get(3).trim();
-        date = record.get(4).trim();
+        date = record.get(4).trim().substring(0,4);
         String[] dcRights = record.get(1).trim()
                 .replaceAll("^\"", "") // strip leading quote
                 .replaceAll("\"$", "") // strip trailing quote

--- a/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
+++ b/src/main/java/nl/knaw/dans/migration/core/SolrFields.java
@@ -31,12 +31,13 @@ public class SolrFields {
 
     private static final Logger log = LoggerFactory.getLogger(EasyFileLoader.class);
 
-    public static String requestedFields = "emd_date_available_formatted,dc_rights,amd_depositor_id,ds_state";
+    public static String requestedFields = "emd_date_available_formatted,dc_rights,amd_depositor_id,ds_state,emd_date_created_formatted";
     private static final CSVFormat solrFormat = CSVFormat.RFC4180.withDelimiter(',');
     final String available;
     final String creator;
     final AccessCategory accessCategory;
     final String state;
+    final String date;
 
     SolrFields (String line) throws IOException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8));
@@ -44,6 +45,7 @@ public class SolrFields {
         available = record.get(0).trim();
         creator = record.get(2).trim();
         state = record.get(3).trim();
+        date = record.get(4).trim();
         String[] dcRights = record.get(1).trim()
                 .replaceAll("^\"", "") // strip leading quote
                 .replaceAll("\"$", "") // strip trailing quote

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -126,7 +126,7 @@ public class VaultLoader extends ExpectedLoader {
       );
       expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
     }
-    log.trace("bag-info.txt created: " + bagInfo.getCreated().substring(0,4));
+    expectedDataset.setCitationYear(bagInfo.getCreated().substring(0,4));
     expectedDataset.setDoi(doi);
     saveExpectedDataset(expectedDataset);
   }

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -28,6 +28,7 @@ import nl.knaw.dans.migration.core.tables.ExpectedDataset;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
@@ -125,6 +126,7 @@ public class VaultLoader extends ExpectedLoader {
       );
       expectedMigrationFiles(doi, migrationFiles, datasetRights.defaultFileRights);
     }
+    log.trace("bag-info.txt created: " + bagInfo.getCreated().substring(0,4));
     expectedDataset.setDoi(doi);
     saveExpectedDataset(expectedDataset);
   }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
@@ -20,12 +20,17 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import java.util.Objects;
 
 @Entity
 @IdClass(ActualDatasetKey.class)
-@Table(name = "actual_datasets")
+@Table(name = "actual_datasets",
+       indexes = {
+           @Index(name = "doi_index", columnList = "doi")
+       }
+)
 public class ActualDataset {
   // https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#schema-generation
 

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualDataset.java
@@ -60,6 +60,9 @@ public class ActualDataset {
   @Column(name="depositor")
   private String depositor;
 
+  @Column(name="citation_year")
+  private String citationYear;
+
   public String getDoi() {
     return doi;
   }
@@ -125,6 +128,14 @@ public class ActualDataset {
     this.depositor = depositor;
   }
 
+  public String getCitationYear() {
+    return citationYear;
+  }
+
+  public void setCitationYear(String citationYear) {
+    this.citationYear = citationYear;
+  }
+
   @Override
   public String toString() {
     return "ActualDataset{" +
@@ -136,6 +147,7 @@ public class ActualDataset {
         ", licenseName='" + licenseName + '\'' +
         ", licenseUri='" + licenseUri + '\'' +
         ", depositor='" + depositor + '\'' +
+        ", citationYear='" + citationYear + '\'' +
         '}';
   }
 
@@ -148,11 +160,11 @@ public class ActualDataset {
     ActualDataset that = (ActualDataset) o;
     return majorVersionNr == that.majorVersionNr && minorVersionNr == that.minorVersionNr && fileAccessRequest == that.fileAccessRequest && deaccessioned == that.deaccessioned
         && Objects.equals(doi, that.doi) && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUri, that.licenseUri) && Objects.equals(
-        depositor, that.depositor);
+        depositor, that.depositor) && Objects.equals(citationYear, that.citationYear);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, deaccessioned, licenseName, licenseUri, depositor);
+    return Objects.hash(doi, majorVersionNr, minorVersionNr, fileAccessRequest, deaccessioned, licenseName, licenseUri, depositor, citationYear);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ActualFile.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ActualFile.java
@@ -23,12 +23,17 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import java.util.Objects;
 
 @Entity
 @IdClass(ActualFileKey.class)
-@Table(name = "actual_files")
+@Table(name = "actual_files",
+       indexes = {
+           @Index(name = "path_index", columnList = "actual_path")
+       }
+)
 public class ActualFile {
   // https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#schema-generation
 

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -56,6 +56,9 @@ public class ExpectedDataset {
     @Column(name = "depositor")
     private String depositor;
 
+    @Column(name="citation_year")
+    private String citationYear;
+
     public String getDoi() {
         return doi;
     }
@@ -99,12 +102,20 @@ public class ExpectedDataset {
         this.license = license;
     }
 
-    public boolean getDeleted() {
+    public boolean isDeleted() {
         return deleted;
     }
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public String getCitationYear() {
+        return citationYear;
+    }
+
+    public void setCitationYear(String citationYear) {
+        this.citationYear = citationYear;
     }
 
     @Override
@@ -114,8 +125,9 @@ public class ExpectedDataset {
             ", accessCategory='" + accessCategory + '\'' +
             ", embargoDate='" + embargoDate + '\'' +
             ", license='" + license + '\'' +
-            ", deleted='" + deleted + '\'' +
+            ", deleted=" + deleted +
             ", depositor='" + depositor + '\'' +
+            ", citationYear='" + citationYear + '\'' +
             '}';
     }
 
@@ -126,12 +138,12 @@ public class ExpectedDataset {
         if (o == null || getClass() != o.getClass())
             return false;
         ExpectedDataset that = (ExpectedDataset) o;
-        return Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(embargoDate, that.embargoDate)
-            && Objects.equals(license, that.license) && Objects.equals(deleted, that.deleted) && Objects.equals(depositor, that.depositor);
+        return deleted == that.deleted && Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(embargoDate,
+            that.embargoDate) && Objects.equals(license, that.license) && Objects.equals(depositor, that.depositor) && Objects.equals(citationYear, that.citationYear);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, accessCategory, embargoDate, license, deleted, depositor);
+        return Objects.hash(doi, accessCategory, embargoDate, license, deleted, depositor, citationYear);
     }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -42,14 +42,6 @@ public class ExpectedDataset {
     @Column(name="access_category")
     private String accessCategory;
 
-    @Nullable
-    @Column(name="embargo_date")
-    private String embargoDate;
-
-    @Nullable
-    @Column(name="license")
-    private String license;
-
     @Column(name="deleted")
     private boolean deleted;
 
@@ -58,6 +50,13 @@ public class ExpectedDataset {
 
     @Column(name="citation_year")
     private String citationYear;
+
+    @Column(name="embargo_date")
+    private String embargoDate;
+
+    @Nullable
+    @Column(name="license")
+    private String license;
 
     public String getDoi() {
         return doi;

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedFile.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedFile.java
@@ -25,12 +25,17 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import java.util.Objects;
 
 @Entity
 @IdClass(ExpectedFileKey.class)
-@Table(name = "expected_files")
+@Table(name = "expected_files",
+       indexes = {
+           @Index(name = "accessible_index", columnList = "accessible_to")
+       }
+)
 public class ExpectedFile {
     // https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#schema-generation
 

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -78,7 +78,7 @@ public class EasyFileLoaderTest {
 
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
     EasyFileDAO easyFileDAO = createMock(EasyFileDAO.class);
-    for (ExpectedFile ef: expectedMigrationFiles("NONE"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     ExpectedDataset expectedDataset = new ExpectedDataset();
@@ -109,7 +109,7 @@ public class EasyFileLoaderTest {
     FedoraToBagCsv csv = mockCSV("OK", "blabla");
     EasyFileDAO easyFileDAO = mockEasyFileDAO();
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
-    for (ExpectedFile ef: expectedMigrationFiles("NONE"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -123,7 +123,7 @@ public class EasyFileLoaderTest {
     FedoraToBagCsv csv = mockCSV("OK", "blabla");
     EasyFileDAO easyFileDAO = mockEasyFileDAO();
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
-    for (ExpectedFile ef: expectedMigrationFiles("ANONYMOUS"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -138,7 +138,7 @@ public class EasyFileLoaderTest {
     FedoraToBagCsv csv = mockCSV("OK", "blabla");
     EasyFileDAO easyFileDAO = mockEasyFileDAO();
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
-    for (ExpectedFile ef: expectedMigrationFiles("RESTRICTED_REQUEST"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -159,7 +159,7 @@ public class EasyFileLoaderTest {
     expectSuccess(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",0,false,"123","easy-file:2","some_/file.txt",false,false,false, "ANONYMOUS", "ANONYMOUS"));
     expectThrows(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",0,false,"123","easy-file:1","some?/file.txt",false,false,true, "ANONYMOUS", "ANONYMOUS"));
     expectSuccess(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",1,false,"123","easy-file:1","some?/file.txt",false,false,true, "ANONYMOUS", "ANONYMOUS"));
-    for (ExpectedFile ef: expectedMigrationFiles("NONE"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -179,7 +179,7 @@ public class EasyFileLoaderTest {
     expectSuccess(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",0,false,"123","easy-file:2","some_/file.txt",false,false,false, "ANONYMOUS", "ANONYMOUS"));
     expectThrows(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",0,true,"123","easy-file:1","original/some?/file.txt",false,false,true, "ANONYMOUS", "ANONYMOUS"));
     expectSuccess(expectedFileDAO, new ExpectedFile(doi,"some_/file.txt",1,true,"123","easy-file:1","original/some?/file.txt",false,false,true, "ANONYMOUS", "ANONYMOUS"));
-    for (ExpectedFile ef: expectedMigrationFiles("NONE"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -197,7 +197,7 @@ public class EasyFileLoaderTest {
     );
     ExpectedFileDAO expectedFileDAO = createMock(ExpectedFileDAO.class);
     expectSuccess(expectedFileDAO, new ExpectedFile(doi,"some_thumbnails/image_small.png",0,false,"123","easy-file:1","some_thumbnails/image_small.png",false,true,false, "ANONYMOUS", "ANONYMOUS"));
-    for (ExpectedFile ef: expectedMigrationFiles("NONE"))
+    for (ExpectedFile ef: expectedMigrationFiles())
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
@@ -220,7 +220,7 @@ public class EasyFileLoaderTest {
     EasyMock.expectLastCall().andThrow(new PersistenceException(new ConstraintViolationException("",null,"blabla"))).once();
   }
 
-  private List<ExpectedFile> expectedMigrationFiles(String rights) {
+  private List<ExpectedFile> expectedMigrationFiles() {
 
     ArrayList<ExpectedFile> expectedFiles = new ArrayList<>();
     for (String f : new String[] { "provenance.xml", "dataset.xml", "files.xml", "emd.xml" }) {
@@ -229,7 +229,7 @@ public class EasyFileLoaderTest {
       expectedFile.setExpectedPath("easy-migration/" + f);
       expectedFile.setAddedDuringMigration(true);
       expectedFiles.add(expectedFile);
-      expectedFile.setAccessibleTo(rights);
+      expectedFile.setAccessibleTo("ANONYMOUS");
       expectedFile.setVisibleTo("ANONYMOUS");
     }
     return expectedFiles;

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -85,6 +85,7 @@ public class EasyFileLoaderTest {
     expectedDataset.setDepositor("somebody");
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.NO_ACCESS);
+    expectedDataset.setCitationYear("2022");
     ExpectedDatasetDAO expectedDatasetDAO = createMock(ExpectedDatasetDAO.class);
     expectSuccess(expectedDatasetDAO, expectedDataset);
 

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -29,7 +29,6 @@ import javax.persistence.PersistenceException;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +41,7 @@ import static org.easymock.EasyMock.verify;
 public class EasyFileLoaderTest {
   private static final String datasetId = "easy-dataset:123";
   private static final String doi = "10.80270/test-nySe-x6f-kf66";
-  private static final String expectedSolr = "2022-03-08," + AccessCategory.NO_ACCESS + ",somebody,PUBLISHED";
+  private static final String expectedSolr = "2022-03-08," + AccessCategory.NO_ACCESS + ",somebody,PUBLISHED,2022-03-25";
 
   private static class Loader extends EasyFileLoader {
 
@@ -127,7 +126,8 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody,PUBLISHED", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
+    String expectedSolr = "\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody,PUBLISHED,2022-03-25";
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -141,7 +141,8 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader("2009-06-04,\"RAAP Archeologisch Adviesbureau,GROUP_ACCESS\",somebody,PUBLISHED", easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
+    String expectedSolr = "2009-06-04,\"RAAP Archeologisch Adviesbureau,GROUP_ACCESS\",somebody,PUBLISHED,2022-03-25";
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 


### PR DESCRIPTION
Fixes DD-919: citation year

# Description of changes

* add citation year to dataset metadata
* use last FileAccessRequest for both versions of a dataset
* added indexes to tabels

# How to test

* build, deploy and run the three types of commands
* for the indexes: in psql examine the result of `\d expected_*` and \d actual_*

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
