### PR TITLE
DD-927: Fix the default license to actually be CC-0

### DIFF
--- a/src/main/assembly/dist/cfg/licenses.csv
+++ b/src/main/assembly/dist/cfg/licenses.csv
@@ -23,7 +23,7 @@ http://www.ohwr.org/attachments/2388/cern_ohl_v_1_2.txt,CERN-OHL-1.2
 http://www.ohwr.org/projects/cernohl/wiki,CERN-OHL-1.2
 http://www.tapr.org/ohl.html,TAPR-OHL-1.0
 http://www.tapr.org/TAPR_Open_Hardware_License_v1.0.txt,TAPR-OHL-1.0
-http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf,DANS_Licence_UK
+https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf,DANS_Licence_UK
 http://www.cecill.info/licences/Licence_CeCILL_V2-en.html,CeCILL_V2
 http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html,CeCILL-B_V1
 http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf,DANS_Licence_UK

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
@@ -32,7 +32,7 @@ public class DatasetLicenseHandler extends DefaultHandler {
 
   private static final Logger log = LoggerFactory.getLogger(DatasetLicenseHandler.class);
 
-  static final String dansLicense = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
+  static final String dansLicense = "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
   static final String cc0 = "http://creativecommons.org/publicdomain/zero/1.0";
   private static final SAXParserFactory parserFactory = configureFactory();
   private StringBuilder chars; // collected since the last startElement

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
@@ -33,7 +33,7 @@ public class DatasetLicenseHandler extends DefaultHandler {
   private static final Logger log = LoggerFactory.getLogger(DatasetLicenseHandler.class);
 
   static final String dansLicense = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
-  static final String cc0 = "http://creativecommons.org/licenses/by/4.0";
+  static final String cc0 = "http://creativecommons.org/publicdomain/zero/1.0";
   private static final SAXParserFactory parserFactory = configureFactory();
   private StringBuilder chars; // collected since the last startElement
   private String license = null;

--- a/src/test/java/nl/knaw/dans/migration/core/DatasetLicenseHandlerTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/DatasetLicenseHandlerTest.java
@@ -31,7 +31,7 @@ public class DatasetLicenseHandlerTest {
     public void parseDD_874() throws IOException {
         String license = DatasetLicenseHandler
             .parseLicense(new FileInputStream("src/test/resources/ddm/DD-874.xml"), AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
-        assertEquals(DatasetLicenseHandler.cc0, license);
+        assertEquals("http://creativecommons.org/licenses/by/4.0", license);
     }
 
     @Test


### PR DESCRIPTION
Fixes DD-927

# Description of changes
* Fix the default license to to actually be CC-0
* Use https instead of http for DansLicense

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
