### PR TITLE
DD-934: expected number of versions for load-from-fedora / load-from-vault

### DIFF
--- a/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetRights.java
@@ -37,10 +37,9 @@ public class DatasetRights {
         this.defaultFileRights = defaultFileRights;
     }
 
-    public ExpectedDataset expectedDataset(String depositor) {
+    public ExpectedDataset expectedDataset() {
         // ExpectedLoader.saveExpectedDataset applies account-substitutes.csv to depositor
         ExpectedDataset expectedDataset = new ExpectedDataset();
-        expectedDataset.setDepositor(depositor);
         expectedDataset.setAccessCategory(accessCategory);
         expectedDataset.setEmbargoDate(defaultFileRights);
         return expectedDataset;

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -22,6 +22,7 @@ import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.EasyFileDAO;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
@@ -66,6 +67,9 @@ public class EasyFileLoader extends ExpectedLoader {
       expected.setDoi(csv.getDoi());
       expected.setCitationYear(solrFields.date);
       expected.setDeleted("DELETED".equals(solrFields.state));
+      if (StringUtils.isNotBlank(csv.getUuid2()))
+         expected.setExpectedVersions(2);
+      else expected.setExpectedVersions(1);
       if (!AccessCategory.NO_ACCESS.equals(solrFields.accessCategory)) {
         byte[] emdBytes = readEmd(csv.getDatasetId())
             .getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -65,6 +65,7 @@ public class EasyFileLoader extends ExpectedLoader {
       DatasetRights datasetRights = solrFields.datasetRights();
       ExpectedDataset expected = datasetRights.expectedDataset(solrFields.creator);
       expected.setDoi(csv.getDoi());
+      expected.setExpectedFilesDoi(csv.getDoi());
       expected.setCitationYear(solrFields.date);
       expected.setDeleted("DELETED".equals(solrFields.state));
       if (StringUtils.isNotBlank(csv.getUuid2()))

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -63,7 +63,8 @@ public class EasyFileLoader extends ExpectedLoader {
     else try {
       SolrFields solrFields = new SolrFields(solrInfo(csv.getDatasetId()));
       DatasetRights datasetRights = solrFields.datasetRights();
-      ExpectedDataset expected = datasetRights.expectedDataset(solrFields.creator);
+      ExpectedDataset expected = datasetRights.expectedDataset();
+      expected.setDepositor(solrFields.creator);
       expected.setDoi(csv.getDoi());
       expected.setCitationYear(solrFields.date);
       expected.setDeleted("DELETED".equals(solrFields.state));

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -65,7 +65,6 @@ public class EasyFileLoader extends ExpectedLoader {
       DatasetRights datasetRights = solrFields.datasetRights();
       ExpectedDataset expected = datasetRights.expectedDataset(solrFields.creator);
       expected.setDoi(csv.getDoi());
-      expected.setExpectedFilesDoi(csv.getDoi());
       expected.setCitationYear(solrFields.date);
       expected.setDeleted("DELETED".equals(solrFields.state));
       if (StringUtils.isNotBlank(csv.getUuid2()))

--- a/src/main/java/nl/knaw/dans/migration/core/FedoraToBagCsv.java
+++ b/src/main/java/nl/knaw/dans/migration/core/FedoraToBagCsv.java
@@ -29,18 +29,24 @@ public class FedoraToBagCsv {
   private final String doi;
   private final String comment;
   private final String transformation;
+  private final String uuid1;
+  private final String uuid2;
   private final CSVRecord r;
 
   private static final String DATASET_ID_COLUMN = "easyDatasetId";
   private static final String DOI_COLUMN = "doi";
   private static final String COMMENT_COLUMN = "comment";
   private static final String TRANSFORMATION_TYPE_COLUMN = "transformationType";
+  private static final String UUID_1 = "uuid1";
+  private static final String UUID_2 = "uuid2";
 
   public FedoraToBagCsv(CSVRecord r) {
     datasetId = r.get(DATASET_ID_COLUMN);
     doi = r.get(DOI_COLUMN);
     comment = r.get(COMMENT_COLUMN);
     transformation = r.get(TRANSFORMATION_TYPE_COLUMN);
+    uuid1 = r.get(UUID_1);
+    uuid2 = r.get(UUID_2);
     this.r = r;
   }
 
@@ -52,7 +58,7 @@ public class FedoraToBagCsv {
   // see https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/8ef3a0bad/src/main/scala/nl/knaw/dans/easy/fedoratobag/CsvRecord.scala#L42-L46
   private static final CSVFormat csvFormat = CSVFormat
       .RFC4180
-      .withHeader(DATASET_ID_COLUMN, "uuid1", "uuid2", DOI_COLUMN, "depositor", TRANSFORMATION_TYPE_COLUMN, COMMENT_COLUMN)
+      .withHeader(DATASET_ID_COLUMN, UUID_1, UUID_2, DOI_COLUMN, "depositor", TRANSFORMATION_TYPE_COLUMN, COMMENT_COLUMN)
       .withDelimiter(',')
       .withFirstRecordAsHeader()
       .withRecordSeparator(System.lineSeparator())
@@ -87,5 +93,13 @@ public class FedoraToBagCsv {
 
   public String getDatasetId() {
     return datasetId;
+  }
+
+  public String getUuid1() {
+    return uuid1;
+  }
+
+  public String getUuid2() {
+    return uuid2;
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -83,54 +83,52 @@ public class VaultLoader extends ExpectedLoader {
       log.info("Skipping {}, it is another version of {}", uuid, bagInfo.getBaseId());
     else {
       log.trace("Processing {}", bagInfo);
+      ExpectedDataset expectedDataset = processBag(uuid.toString(), bagInfo, bagInfo.getDoi());
       String[] bagSeq = readBagSequence(uuid);
-      if (bagSeq.length <= 1)
-        processBag(uuid.toString(), bagInfo, 1, bagInfo.getDoi());
-      else {
+      if (bagSeq.length > 1) {
         List<BagInfo> bagInfos= StreamSupport
             .stream(Arrays.stream(bagSeq).spliterator(), false)
             .map(this::readBagInfo)
             .sorted(new BagInfoComparator()).collect(Collectors.toList());
-        for (int i = 0; i < bagInfos.size(); i++) {
+        for (int i = 1; i < bagInfos.size(); i++) {
           BagInfo info = bagInfos.get(i);
           log.trace("{} from sequence {}", i, info);
-          processBag(info.getBaseId(), info, i, bagInfos.get(0).getDoi());
+          expectedDataset = processBag(info.getBaseId(), info, bagInfos.get(0).getDoi());
         }
       }
+      expectedDataset.setDepositor(readDepositor(uuid.toString()));
+      expectedDataset.setCitationYear(bagInfo.getCreated().substring(0,4));
+      expectedDataset.setDoi(bagInfo.getDoi());
+      expectedDataset.setExpectedVersions(bagSeq.length);
+      saveExpectedDataset(expectedDataset);
     }
   }
 
   /** note: easy-convert-bag-to-deposit does not add emd.xml to bags from the vault */
   private static final String[] migrationFiles = { "provenance.xml", "dataset.xml", "files.xml" };
 
-  private void processBag(String uuid, BagInfo bagInfo, int seqNr, String baseDoi) {
+  /** @return either deleted=true or accessCategory, embargoDate and license */
+  private ExpectedDataset processBag(String uuid, BagInfo bagInfo, String baseDoi) {
     byte[] ddmBytes = readDDM(uuid).getBytes(StandardCharsets.UTF_8);// parsed twice to reuse code shared with EasyFileLoader
     ExpectedDataset expectedDataset;
     if (ddmBytes.length == 0) {
-      expectedDataset = new ExpectedDataset();
       // presuming deactivated, logging shows whether it was indeed deactivated or not found
+      expectedDataset = new ExpectedDataset();
       expectedDataset.setDeleted(true);
     } else {
-      String depositor = readDepositor(uuid);
       DatasetRights datasetRights = DatasetRightsHandler.parseRights(new ByteArrayInputStream(ddmBytes));
-      expectedDataset = datasetRights.expectedDataset(depositor);
+      expectedDataset = datasetRights.expectedDataset();
       expectedDataset.setLicenseUrl(DatasetLicenseHandler.parseLicense(new ByteArrayInputStream(ddmBytes), datasetRights.accessCategory));
-      // now that we collected everything from the bag, we start processing the files
-      String currentDoi = bagInfo.getDoi(); // TODO use baseDoi, but what about seqNr?
       Map<String, FileRights> filesXml = readFileMeta(uuid);
       readManifest(uuid).forEach(m ->
-          createExpected(currentDoi, m, filesXml, datasetRights.defaultFileRights)
+          createExpectedFile(baseDoi, m, filesXml, datasetRights.defaultFileRights)
       );
-      expectedMigrationFiles(currentDoi, migrationFiles, datasetRights.defaultFileRights);
+      expectedMigrationFiles(baseDoi, migrationFiles, datasetRights.defaultFileRights);
     }
-    expectedDataset.setCitationYear(bagInfo.getCreated().substring(0,4));
-    // TODO Note that for fedora only one record is saved for original-versioned datasets
-    expectedDataset.setDoi(baseDoi);// TODO save currentDoi too, to match up with expectedFiles?
-    expectedDataset.setExpectedVersions(seqNr);
-    saveExpectedDataset(expectedDataset);
+    return expectedDataset;
   }
 
-  private void createExpected(String doi, ManifestCsv m, Map<String, FileRights> fileRightsMap, FileRights defaultFileRights) {
+  private void createExpectedFile(String doi, ManifestCsv m, Map<String, FileRights> fileRightsMap, FileRights defaultFileRights) {
     String path = m.getPath();
     FileRights fileRights = fileRightsMap.get(path).applyDefaults(defaultFileRights);
     log.trace("{} {}", path, fileRights);
@@ -179,7 +177,7 @@ public class VaultLoader extends ExpectedLoader {
     }
   }
 
-  private String readDepositor(String uuid) {
+    private String readDepositor(String uuid) {
     URI uri = bagStoreBaseUri
         .resolve("bags/")
         .resolve(uuid+"/")

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -85,7 +85,7 @@ public class VaultLoader extends ExpectedLoader {
       log.trace("Processing {}", bagInfo);
       String[] bagSeq = readBagSequence(uuid);
       if (bagSeq.length <= 1)
-        processBag(uuid.toString(), bagInfo, 1, 1, bagInfo.getDoi());
+        processBag(uuid.toString(), bagInfo, 1, bagInfo.getDoi());
       else {
         List<BagInfo> bagInfos= StreamSupport
             .stream(Arrays.stream(bagSeq).spliterator(), false)
@@ -94,7 +94,7 @@ public class VaultLoader extends ExpectedLoader {
         for (int i = 0; i < bagInfos.size(); i++) {
           BagInfo info = bagInfos.get(i);
           log.trace("{} from sequence {}", i, info);
-          processBag(info.getBaseId(), info, i, bagInfos.size(), bagInfos.get(0).getDoi());
+          processBag(info.getBaseId(), info, i, bagInfos.get(0).getDoi());
         }
       }
     }
@@ -103,8 +103,7 @@ public class VaultLoader extends ExpectedLoader {
   /** note: easy-convert-bag-to-deposit does not add emd.xml to bags from the vault */
   private static final String[] migrationFiles = { "provenance.xml", "dataset.xml", "files.xml" };
 
-  private void processBag(String uuid, BagInfo bagInfo, int seqNr, int bagSeqLength, String baseDoi) {
-    String currentDoi = bagInfo.getDoi();
+  private void processBag(String uuid, BagInfo bagInfo, int seqNr, String baseDoi) {
     byte[] ddmBytes = readDDM(uuid).getBytes(StandardCharsets.UTF_8);// parsed twice to reuse code shared with EasyFileLoader
     ExpectedDataset expectedDataset;
     if (ddmBytes.length == 0) {
@@ -116,8 +115,8 @@ public class VaultLoader extends ExpectedLoader {
       DatasetRights datasetRights = DatasetRightsHandler.parseRights(new ByteArrayInputStream(ddmBytes));
       expectedDataset = datasetRights.expectedDataset(depositor);
       expectedDataset.setLicenseUrl(DatasetLicenseHandler.parseLicense(new ByteArrayInputStream(ddmBytes), datasetRights.accessCategory));
-      expectedDataset.setExpectedFilesDoi(currentDoi);
       // now that we collected everything from the bag, we start processing the files
+      String currentDoi = bagInfo.getDoi(); // TODO use baseDoi, but what about seqNr?
       Map<String, FileRights> filesXml = readFileMeta(uuid);
       readManifest(uuid).forEach(m ->
           createExpected(currentDoi, m, filesXml, datasetRights.defaultFileRights)
@@ -125,8 +124,9 @@ public class VaultLoader extends ExpectedLoader {
       expectedMigrationFiles(currentDoi, migrationFiles, datasetRights.defaultFileRights);
     }
     expectedDataset.setCitationYear(bagInfo.getCreated().substring(0,4));
-    expectedDataset.setDoi(baseDoi);
-    expectedDataset.setExpectedVersions(bagSeqLength);
+    // TODO Note that for fedora only one record is saved for original-versioned datasets
+    expectedDataset.setDoi(baseDoi);// TODO save currentDoi too, to match up with expectedFiles?
+    expectedDataset.setExpectedVersions(seqNr);
     saveExpectedDataset(expectedDataset);
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -39,10 +39,6 @@ public class ExpectedDataset {
     @Column(length = 255)
     private String doi;
 
-    @Id
-    @Column(length = 255, name="expected_files_doi")
-    private String expectedFilesDoi;
-
     @Column(name="access_category")
     private String accessCategory;
 
@@ -76,14 +72,6 @@ public class ExpectedDataset {
 
     public void setDoi(String doi) {
         this.doi = doi;
-    }
-
-    public String getExpectedFilesDoi() {
-        return expectedFilesDoi;
-    }
-
-    public void setExpectedFilesDoi(String expectedFilesDoi) {
-        this.expectedFilesDoi = expectedFilesDoi;
     }
 
     public String getAccessCategory() {
@@ -159,7 +147,6 @@ public class ExpectedDataset {
     public String toString() {
         return "ExpectedDataset{" +
             "doi='" + doi + '\'' +
-            ", expectedFilesDoi='" + expectedFilesDoi + '\'' +
             ", accessCategory='" + accessCategory + '\'' +
             ", deleted=" + deleted +
             ", depositor='" + depositor + '\'' +
@@ -167,7 +154,7 @@ public class ExpectedDataset {
             ", embargoDate='" + embargoDate + '\'' +
             ", licenseName='" + licenseName + '\'' +
             ", licenseUrl='" + licenseUrl + '\'' +
-            ", expectedVersions=" + expectedVersions +
+            ", expectedVersions='" + expectedVersions + '\'' +
             '}';
     }
 
@@ -178,13 +165,13 @@ public class ExpectedDataset {
         if (o == null || getClass() != o.getClass())
             return false;
         ExpectedDataset that = (ExpectedDataset) o;
-        return deleted == that.deleted && expectedVersions == that.expectedVersions && Objects.equals(doi, that.doi) && Objects.equals(expectedFilesDoi, that.expectedFilesDoi)
-            && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor) && Objects.equals(citationYear, that.citationYear)
-            && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUrl, that.licenseUrl);
+        return deleted == that.deleted && Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor)
+            && Objects.equals(citationYear, that.citationYear) && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(licenseName, that.licenseName)
+            && Objects.equals(licenseUrl, that.licenseUrl) && Objects.equals(expectedVersions, that.expectedVersions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, expectedFilesDoi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl, expectedVersions);
+        return Objects.hash(doi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl, expectedVersions);
     }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -62,6 +62,10 @@ public class ExpectedDataset {
     @Column(name="license_url")
     private String licenseUrl;
 
+    @Nullable
+    @Column(name="expected_versions")
+    private int expectedVersions;
+
     public String getDoi() {
         return doi;
     }
@@ -130,6 +134,15 @@ public class ExpectedDataset {
         this.licenseName = licenseName;
     }
 
+    @Nullable
+    public int getExpectedVersions() {
+        return expectedVersions;
+    }
+
+    public void setExpectedVersions(@Nullable int expectedVersions) {
+        this.expectedVersions = expectedVersions;
+    }
+
     @Override
     public String toString() {
         return "ExpectedDataset{" +
@@ -141,6 +154,7 @@ public class ExpectedDataset {
             ", embargoDate='" + embargoDate + '\'' +
             ", licenseName='" + licenseName + '\'' +
             ", licenseUrl='" + licenseUrl + '\'' +
+            ", expectedVersions='" + expectedVersions + '\'' +
             '}';
     }
 
@@ -153,11 +167,11 @@ public class ExpectedDataset {
         ExpectedDataset that = (ExpectedDataset) o;
         return deleted == that.deleted && Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor)
             && Objects.equals(citationYear, that.citationYear) && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(licenseName, that.licenseName)
-            && Objects.equals(licenseUrl, that.licenseUrl);
+            && Objects.equals(licenseUrl, that.licenseUrl) && Objects.equals(expectedVersions, that.expectedVersions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl);
+        return Objects.hash(doi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl, expectedVersions);
     }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDataset.java
@@ -39,6 +39,10 @@ public class ExpectedDataset {
     @Column(length = 255)
     private String doi;
 
+    @Id
+    @Column(length = 255, name="expected_files_doi")
+    private String expectedFilesDoi;
+
     @Column(name="access_category")
     private String accessCategory;
 
@@ -72,6 +76,14 @@ public class ExpectedDataset {
 
     public void setDoi(String doi) {
         this.doi = doi;
+    }
+
+    public String getExpectedFilesDoi() {
+        return expectedFilesDoi;
+    }
+
+    public void setExpectedFilesDoi(String expectedFilesDoi) {
+        this.expectedFilesDoi = expectedFilesDoi;
     }
 
     public String getAccessCategory() {
@@ -147,6 +159,7 @@ public class ExpectedDataset {
     public String toString() {
         return "ExpectedDataset{" +
             "doi='" + doi + '\'' +
+            ", expectedFilesDoi='" + expectedFilesDoi + '\'' +
             ", accessCategory='" + accessCategory + '\'' +
             ", deleted=" + deleted +
             ", depositor='" + depositor + '\'' +
@@ -154,7 +167,7 @@ public class ExpectedDataset {
             ", embargoDate='" + embargoDate + '\'' +
             ", licenseName='" + licenseName + '\'' +
             ", licenseUrl='" + licenseUrl + '\'' +
-            ", expectedVersions='" + expectedVersions + '\'' +
+            ", expectedVersions=" + expectedVersions +
             '}';
     }
 
@@ -165,13 +178,13 @@ public class ExpectedDataset {
         if (o == null || getClass() != o.getClass())
             return false;
         ExpectedDataset that = (ExpectedDataset) o;
-        return deleted == that.deleted && Objects.equals(doi, that.doi) && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor)
-            && Objects.equals(citationYear, that.citationYear) && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(licenseName, that.licenseName)
-            && Objects.equals(licenseUrl, that.licenseUrl) && Objects.equals(expectedVersions, that.expectedVersions);
+        return deleted == that.deleted && expectedVersions == that.expectedVersions && Objects.equals(doi, that.doi) && Objects.equals(expectedFilesDoi, that.expectedFilesDoi)
+            && Objects.equals(accessCategory, that.accessCategory) && Objects.equals(depositor, that.depositor) && Objects.equals(citationYear, that.citationYear)
+            && Objects.equals(embargoDate, that.embargoDate) && Objects.equals(licenseName, that.licenseName) && Objects.equals(licenseUrl, that.licenseUrl);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl, expectedVersions);
+        return Objects.hash(doi, expectedFilesDoi, accessCategory, deleted, depositor, citationYear, embargoDate, licenseName, licenseUrl, expectedVersions);
     }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDatasetKey.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDatasetKey.java
@@ -20,18 +20,18 @@ import java.util.Objects;
 
 public class ExpectedDatasetKey implements Serializable {
 
-  private String doi;
+  private String expectedFilesDoi;
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ExpectedDatasetKey that = (ExpectedDatasetKey) o;
-    return Objects.equals(doi, that.doi);
+    return Objects.equals(expectedFilesDoi, that.expectedFilesDoi);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(doi);
+    return Objects.hash(expectedFilesDoi);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDatasetKey.java
+++ b/src/main/java/nl/knaw/dans/migration/core/tables/ExpectedDatasetKey.java
@@ -20,18 +20,18 @@ import java.util.Objects;
 
 public class ExpectedDatasetKey implements Serializable {
 
-  private String expectedFilesDoi;
+  private String doi;
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ExpectedDatasetKey that = (ExpectedDatasetKey) o;
-    return Objects.equals(expectedFilesDoi, that.expectedFilesDoi);
+    return Objects.equals(doi, that.doi);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(expectedFilesDoi);
+    return Objects.hash(doi);
   }
 }

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -85,6 +85,7 @@ public class EasyFileLoaderTest {
     ExpectedDataset expectedDataset = new ExpectedDataset();
     expectedDataset.setDepositor("somebody");
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
+    expectedDataset.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.NO_ACCESS);
     expectedDataset.setCitationYear("2022");
     expectedDataset.setExpectedVersions(1);
@@ -124,6 +125,7 @@ public class EasyFileLoaderTest {
     ExpectedDataset expectedDataset = new ExpectedDataset();
     expectedDataset.setDepositor("somebody");
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
+    expectedDataset.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.OPEN_ACCESS);
     expectedDataset.setCitationYear("2022");
     expectedDataset.setLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0");
@@ -169,12 +171,13 @@ public class EasyFileLoaderTest {
     uuidToVersions.forEach((uuid,count) -> {
       FedoraToBagCsv csv = createMock(FedoraToBagCsv.class);
       expect(csv.getComment()).andReturn("OK").once();
-      expect(csv.getDoi()).andReturn(doi).once();
+      expect(csv.getDoi()).andReturn(doi).times(2);
       expect(csv.getUuid2()).andReturn(uuid).once();
       expect(csv.getDatasetId()).andReturn(datasetId).times(2);// once to read solr, once to read EMD
 
       ExpectedDataset ed = new ExpectedDataset();
       ed.setDoi("10.80270/test-nySe-x6f-kf66");
+      ed.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
       ed.setAccessCategory(AccessCategory.GROUP_ACCESS);
       ed.setDeleted(false);
       ed.setDepositor("somebody");

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -87,6 +87,7 @@ public class EasyFileLoaderTest {
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.NO_ACCESS);
     expectedDataset.setCitationYear("2022");
+    expectedDataset.setExpectedVersions(1);
     ExpectedDatasetDAO expectedDatasetDAO = createMock(ExpectedDatasetDAO.class);
     expectSuccess(expectedDatasetDAO, expectedDataset);
 
@@ -127,6 +128,7 @@ public class EasyFileLoaderTest {
     expectedDataset.setCitationYear("2022");
     expectedDataset.setLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0");
     expectedDataset.setLicenseName("CC0-1.0");
+    expectedDataset.setExpectedVersions(1);
     ExpectedDatasetDAO expectedDatasetDAO = createMock(ExpectedDatasetDAO.class);
     expectSuccess(expectedDatasetDAO, expectedDataset);
 
@@ -285,6 +287,7 @@ public class EasyFileLoaderTest {
     expect(mockedCSV.getComment()).andReturn(comment).anyTimes();
     expect(mockedCSV.getTransformation()).andReturn(type).anyTimes();
     expect(mockedCSV.getDoi()).andReturn(doi).anyTimes();
+    expect(mockedCSV.getUuid2()).andReturn("").anyTimes();
     expect(mockedCSV.getDatasetId()).andReturn(datasetId).anyTimes();
     return mockedCSV;
   }

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -85,7 +85,6 @@ public class EasyFileLoaderTest {
     ExpectedDataset expectedDataset = new ExpectedDataset();
     expectedDataset.setDepositor("somebody");
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
-    expectedDataset.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.NO_ACCESS);
     expectedDataset.setCitationYear("2022");
     expectedDataset.setExpectedVersions(1);
@@ -125,7 +124,6 @@ public class EasyFileLoaderTest {
     ExpectedDataset expectedDataset = new ExpectedDataset();
     expectedDataset.setDepositor("somebody");
     expectedDataset.setDoi("10.80270/test-nySe-x6f-kf66");
-    expectedDataset.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
     expectedDataset.setAccessCategory(AccessCategory.OPEN_ACCESS);
     expectedDataset.setCitationYear("2022");
     expectedDataset.setLicenseUrl("http://creativecommons.org/publicdomain/zero/1.0");
@@ -171,13 +169,12 @@ public class EasyFileLoaderTest {
     uuidToVersions.forEach((uuid,count) -> {
       FedoraToBagCsv csv = createMock(FedoraToBagCsv.class);
       expect(csv.getComment()).andReturn("OK").once();
-      expect(csv.getDoi()).andReturn(doi).times(2);
+      expect(csv.getDoi()).andReturn(doi).once();
       expect(csv.getUuid2()).andReturn(uuid).once();
       expect(csv.getDatasetId()).andReturn(datasetId).times(2);// once to read solr, once to read EMD
 
       ExpectedDataset ed = new ExpectedDataset();
       ed.setDoi("10.80270/test-nySe-x6f-kf66");
-      ed.setExpectedFilesDoi("10.80270/test-nySe-x6f-kf66");
       ed.setAccessCategory(AccessCategory.GROUP_ACCESS);
       ed.setDeleted(false);
       ed.setDepositor("somebody");


### PR DESCRIPTION
Fixes DD-934: expected number of versions for load-from-fedora / load-from-vault

# Description of changes
* Note that for fedora only one record is saved for original-versioned datasets, for the vault a record per bag is saved
* added not only a column `expected_versions` (not sure any more this should be plural or single), but also `expectded_files_doi`

# How to test

* load a sequence of bags in the vault
  * in `easy-sword2-dans-examples` execute `./run.sh SequenceSimple https://deasy.dans.knaw.nl/sword2/collection/1 user001 user001 src/main/resources/agreement-flow/valid/revision*`
* [x] collect the uuids in a txt file and execute `start.sh load-from-vault -u etc/uuids.txt`
* [x] or build, deploy and run on deasy

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
