### PR TITLE
NO JIRA ISSUE: delete csv-DOIs before insert

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ ARGUMENTS
 
       named arguments:
         -c [FILE], --config [FILE]   application configuration file (default: etc/config.yml)
-        --mode {ALL,FILES,DATASETS}  files require more writing, dataset require more reading (default: ALL)
+        --mode {ALL,FILES,DATASETS}  files require more writing, dataset require more reading (default: DATASETS)
         -h, --help                   show this help message and exit
 
 EXAMPLES

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,7 @@ ARGUMENTS
 
       named arguments:
         -c [FILE], --config [FILE]   application configuration file (default: etc/config.yml)
-        -f [{true,false}], --withFiles [{true,false}]
-                                     The table expected_files is not filled without this option (default: false)
+        --mode {ALL,FILES,DATASETS}  files require more writing, dataset require more reading (default: ALL)
         -h, --help                   show this help message and exit
 
 EXAMPLES

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
@@ -45,7 +45,6 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
     private static final Logger log = LoggerFactory.getLogger(LoadFromFedoraCommand.class);
     private final HibernateBundle<DdVerifyMigrationConfiguration> easyBundle;
     private final HibernateBundle<DdVerifyMigrationConfiguration> verificationBundle;
-    private final String WITH_FILES = "withFiles";
     private final String CSV = "csv";
 
     /**

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromVaultCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromVaultCommand.java
@@ -24,6 +24,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import nl.knaw.dans.lib.util.DefaultConfigEnvironmentCommand;
 import nl.knaw.dans.migration.DdVerifyMigrationConfiguration;
+import nl.knaw.dans.migration.core.Mode;
 import nl.knaw.dans.migration.core.VaultLoader;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
@@ -59,6 +60,9 @@ public class LoadFromVaultCommand extends DefaultConfigEnvironmentCommand<DdVeri
     public void configure(Subparser subparser) {
         super.addFileArgument(subparser);
 
+        Mode.configure(
+            subparser.addArgument("--mode")
+        );
         MutuallyExclusiveGroup group = subparser.addMutuallyExclusiveGroup().required(true);
         group.addArgument("-u", "--uuids")
             .dest("uuids")
@@ -93,12 +97,13 @@ public class LoadFromVaultCommand extends DefaultConfigEnvironmentCommand<DdVeri
         String uuid = namespace.getString("uuid");
         String file = namespace.getString("uuids");
         String store = namespace.getString("store");
+        Mode mode = Mode.from(namespace);
         if (uuid != null)
-            proxy.loadFromVault(UUID.fromString(uuid));
+            proxy.loadFromVault(UUID.fromString(uuid), mode);
         else if (file != null) {
             String uuids = FileUtils.readFileToString(new File(file), Charset.defaultCharset());
             for (String s : uuids.split(System.lineSeparator())) {
-                proxy.loadFromVault(UUID.fromString(s.trim()));
+                proxy.loadFromVault(UUID.fromString(s.trim()), mode);
             }
         }
         else {

--- a/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
@@ -15,14 +15,18 @@
  */
 package nl.knaw.dans.migration.core;
 
+import io.dropwizard.hibernate.UnitOfWork;
 import nl.knaw.dans.migration.core.tables.ExpectedDataset;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 public class ExpectedLoader {
@@ -40,7 +44,14 @@ public class ExpectedLoader {
     this.licensesUrlToName = Mapping.load(new File(configDir + "/licenses.csv"),"url","name");
   }
 
-  public void expectedMigrationFiles(String doi, String[] migrationFiles, FileRights datasetRights, String easyFileId) {
+  public void deleteByDoi(String doi, Mode mode) {
+    if (mode.doFiles())
+      expectedFileDAO.deleteByDoi(doi);
+    if (mode.doDatasets())
+      expectedDatasetDAO.deleteByDoi(doi);
+  }
+
+  public void expectedMigrationFiles(String doi, String[] migrationFiles, String easyFileId) {
     for (String f: migrationFiles) {
       ExpectedFile expectedFile = new ExpectedFile();
       expectedFile.setDoi(doi);

--- a/src/main/java/nl/knaw/dans/migration/core/Mode.java
+++ b/src/main/java/nl/knaw/dans/migration/core/Mode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.migration.core;
+
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public enum Mode {ALL, FILES, DATASETS;
+
+    public boolean doDatasets() {
+        return !Mode.FILES.equals(this);
+    }
+    public boolean doFiles() {
+        return !Mode.DATASETS.equals(this);
+    }
+
+    public static Argument configure(Argument argument) {
+        return argument
+            .dest("mode")
+            .setDefault(Mode.ALL)
+            .type(Mode.class)
+            .help("files require more writing, datasets require more reading");
+    }
+
+    public static Mode from(Namespace namespace) {
+        return Mode.valueOf(namespace.getString("mode"));
+    }
+}

--- a/src/main/java/nl/knaw/dans/migration/core/Mode.java
+++ b/src/main/java/nl/knaw/dans/migration/core/Mode.java
@@ -30,7 +30,7 @@ public enum Mode {ALL, FILES, DATASETS;
     public static Argument configure(Argument argument) {
         return argument
             .dest("mode")
-            .setDefault(Mode.ALL)
+            .setDefault(Mode.DATASETS)
             .type(Mode.class)
             .help("files require more writing, datasets require more reading");
     }

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -129,7 +129,7 @@ public class VaultLoader extends ExpectedLoader {
       readManifest(uuid).forEach(m ->
           createExpectedFile(baseDoi, bagSeqNr, m, filesXml, datasetRights.defaultFileRights)
       );
-      expectedMigrationFiles(baseDoi, migrationFiles, datasetRights.defaultFileRights, String.valueOf(bagSeqNr));
+      expectedMigrationFiles(baseDoi, migrationFiles, String.valueOf(bagSeqNr));
     }
     return expectedDataset;
   }

--- a/src/main/java/nl/knaw/dans/migration/db/ExpectedDatasetDAO.java
+++ b/src/main/java/nl/knaw/dans/migration/db/ExpectedDatasetDAO.java
@@ -17,7 +17,9 @@ package nl.knaw.dans.migration.db;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import nl.knaw.dans.migration.core.tables.ExpectedDataset;
+import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,5 +33,14 @@ public class ExpectedDatasetDAO extends AbstractDAO<ExpectedDatasetDAO> {
   public void create(ExpectedDataset expected) {
     log.trace(expected.toString());
     currentSession().save(expected);
+  }
+
+  public void deleteByDoi(String doi) {
+    log.trace("deleting ExpectedDataset {}", doi);
+    int r = currentSession()
+        .createQuery("DELETE FROM ExpectedDataset WHERE doi = :doi")
+        .setParameter("doi", doi)
+        .executeUpdate();
+    log.trace("deleted {} from ExpectedDataset", r);
   }
 }

--- a/src/main/java/nl/knaw/dans/migration/db/ExpectedFileDAO.java
+++ b/src/main/java/nl/knaw/dans/migration/db/ExpectedFileDAO.java
@@ -16,10 +16,15 @@
 package nl.knaw.dans.migration.db;
 
 import io.dropwizard.hibernate.AbstractDAO;
+import nl.knaw.dans.migration.core.tables.EasyFile;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.persistence.criteria.CriteriaQuery;
+import java.util.List;
 
 public class ExpectedFileDAO extends AbstractDAO<ExpectedFileDAO> {
   private static final Logger log = LoggerFactory.getLogger(ExpectedFileDAO.class);
@@ -31,5 +36,14 @@ public class ExpectedFileDAO extends AbstractDAO<ExpectedFileDAO> {
   public void create(ExpectedFile expected) {
     log.trace(expected.toString());
     currentSession().save(expected);
+  }
+
+  public void deleteByDoi(String doi) {
+    log.trace("deleting ExpectedFile {}", doi);
+    int r = currentSession()
+        .createQuery("DELETE FROM ExpectedFile WHERE doi = :doi")
+        .setParameter("doi", doi)
+        .executeUpdate();
+    log.trace("deleted {} from ExpectedFile", r);
   }
 }

--- a/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/EasyFileLoaderTest.java
@@ -92,7 +92,7 @@ public class EasyFileLoaderTest {
     expectSuccess(expectedDatasetDAO, expectedDataset);
 
     replay(csv, expectedFileDAO, easyFileDAO, expectedDatasetDAO);
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, expectedDatasetDAO).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, expectedDatasetDAO).loadFromCsv(csv, Mode.ALL);
     verify(csv, expectedFileDAO, easyFileDAO, expectedDatasetDAO);
   }
 
@@ -101,7 +101,7 @@ public class EasyFileLoaderTest {
 
     FedoraToBagCsv csv = mockCSV("Failed for some reason", "blabla");
     replay(csv);
-    new Loader(null, null, null, null).loadFromCsv(csv, true);
+    new Loader(null, null, null, null).loadFromCsv(csv, Mode.ALL);
     verify(csv);
   }
 
@@ -115,7 +115,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -140,7 +140,7 @@ public class EasyFileLoaderTest {
 
     replay(csv, easyFileDAO, expectedFileDAO, expectedDatasetDAO);
     String expectedSolr = "\"\",\"OPEN_ACCESS,accept,http://creativecommons.org/licenses/by/4.0,Econsultancy\",somebody,PUBLISHED,2022-03-25";
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, expectedDatasetDAO).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, expectedDatasetDAO).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO, expectedDatasetDAO);
   }
 
@@ -155,7 +155,7 @@ public class EasyFileLoaderTest {
 
     replay(csv, easyFileDAO, expectedFileDAO);
     String expectedSolr = "2009-06-04,\"RAAP Archeologisch Adviesbureau,GROUP_ACCESS\",somebody,PUBLISHED,2022-03-25";
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -188,7 +188,7 @@ public class EasyFileLoaderTest {
 
       replay(csv, expectedDatasetDAO);
       String expectedSolr = "2009-06-04,GROUP_ACCESS,somebody,PUBLISHED,2022-03-25";
-      new Loader(expectedSolr, null, null, expectedDatasetDAO).loadFromCsv(csv, false);
+      new Loader(expectedSolr, null, null, expectedDatasetDAO).loadFromCsv(csv, Mode.DATASETS);
       verify(csv, expectedDatasetDAO);
     });
   }
@@ -210,7 +210,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -230,7 +230,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 
@@ -248,7 +248,7 @@ public class EasyFileLoaderTest {
       expectSuccess(expectedFileDAO, ef);
 
     replay(csv, easyFileDAO, expectedFileDAO);
-    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, true);
+    new Loader(expectedSolr, easyFileDAO, expectedFileDAO, createMock(ExpectedDatasetDAO.class)).loadFromCsv(csv, Mode.ALL);
     verify(csv, easyFileDAO, expectedFileDAO);
   }
 


### PR DESCRIPTION
Fixes DD-

# Description of changes
* load-from-fedora 
  * at the start: delete all DOIs from expected tables for CSV records with `OK` in comment field 
  * change `--withFiles` into `--mode` 
* load-from-vault
  * per bag(sequence): delete DOI from expected tables 
  * new:  `--mode` 

# How to test

In the root of the local repository

* configure `ect/config.yml` to connect with deasy services

* in one terminal:

      mvn clean install ; start-hsqldb.sh

* in another terminal run both twice (the second run used to cause duplicate errors, it won't now)

      start.sh load-from-fedora --mode ALL  some.csv
      start.sh load-from-vault --mode ALL -u uuids.txt

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
