### PR TITLE
NO JIRA ISSUE: standard --mode + delete for load-from-dataverse

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ ARGUMENTS
         file                         application configuration file (default: etc/config.yml)
 
       named arguments:     
+        --mode {ALL,FILES,DATASETS}  files require more writing, dataset require more reading (default: DATASETS)
         -u UUIDS, --uuids UUIDS      file with UUIDs of a bag in the vault
         -U UUID, --UUID UUID         UUID of a bag in the vault
         -s STORE, --store STORE      name of a bag store in the vault

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromDataverseCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromDataverseCommand.java
@@ -95,6 +95,7 @@ public class LoadFromDataverseCommand extends DefaultConfigEnvironmentCommand<Dd
     @Override
     protected void run(Environment environment, Namespace namespace, DdVerifyMigrationConfiguration configuration) throws Exception {
         // https://www.dropwizard.io/en/stable/manual/hibernate.html#transactional-resource-methods-outside-jersey-resources
+        log.info("dataverse: {}", configuration.getDataverse().getBaseUrl());
         DataverseClient client = configuration.getDataverse().build();
         SessionFactory verificationBundleSessionFactory = verificationBundle.getSessionFactory();
         DataverseLoader proxy = new UnitOfWorkAwareProxyFactory(verificationBundle)

--- a/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
+++ b/src/main/java/nl/knaw/dans/migration/cli/LoadFromFedoraCommand.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import javax.naming.ConfigurationException;
 import java.io.File;
 import java.net.URI;
-import java.util.Arrays;
 
 public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVerifyMigrationConfiguration> {
 
@@ -112,7 +111,7 @@ public class LoadFromFedoraCommand extends DefaultConfigEnvironmentCommand<DdVer
         Mode mode = Mode.from(namespace);
         for (File csvFile : namespace.<File> getList(CSV)) {
             log.info(csvFile.toString());
-            proxy.deleteFromCsv(FedoraToBagCsv.parse(csvFile), mode);
+            proxy.deleteCsvDOIs(FedoraToBagCsv.parse(csvFile), mode);
             for (CSVRecord r : FedoraToBagCsv.parse(csvFile)) {
                 proxy.loadFromCsv(new FedoraToBagCsv(r), mode);
             }

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -32,6 +32,8 @@ import nl.knaw.dans.migration.core.tables.ActualDataset;
 import nl.knaw.dans.migration.core.tables.ActualFile;
 import nl.knaw.dans.migration.db.ActualDatasetDAO;
 import nl.knaw.dans.migration.db.ActualFileDAO;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.hsqldb.lib.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +55,37 @@ public class DataverseLoader {
     }
 
     @UnitOfWork("hibernate")
-    public void loadFromDataset(String doi, boolean doFiles, boolean doDatasets) {
+    public void deleteCsvDOIs(CSVParser csvRecords, Mode mode) {
+        for (CSVRecord r : csvRecords) {
+            FedoraToBagCsv fedoraToBagCsv = new FedoraToBagCsv(r);
+            if (fedoraToBagCsv.getComment().contains("OK")) {
+                deleteByDoi(fedoraToBagCsv.getDoi(), mode);
+            }
+        }
+    }
+
+    @UnitOfWork("hibernate")
+    public void deleteSingleDoi(String doi, Mode mode) {
+        deleteByDoi(doi, mode);
+    }
+
+    @UnitOfWork("hibernate")
+    public void deleteAll(Mode mode) {
+        if (mode.doFiles())
+            actualFileDAO.deleteAll();
+        if (mode.doDatasets())
+            actualDatasetDAO.deleteAll();
+    }
+
+    public void deleteByDoi(String doi, Mode mode) {
+        if (mode.doFiles())
+            actualFileDAO.deleteByDoi(doi);
+        if (mode.doDatasets())
+            actualDatasetDAO.deleteByDoi(doi);
+    }
+
+    @UnitOfWork("hibernate")
+    public void loadFromDataset(String doi, Mode mode) {
         if (StringUtil.isEmpty(doi))
             return; // workaround
         log.info("Reading {} from dataverse", doi);
@@ -66,7 +98,7 @@ public class DataverseLoader {
         String shortDoi = doi.replace("doi:", "");
         load(doi, versionsLoader, DatasetVersion.class, doi).ifPresent(versions ->
             versions.forEach(v -> {
-                if (doDatasets) {
+                if (mode.doDatasets()) {
                     ActualDataset actualDataset = new ActualDataset();
                     actualDataset.setMajorVersionNr(v.getVersionNumber());
                     actualDataset.setMinorVersionNr(v.getVersionMinorNumber());
@@ -93,7 +125,7 @@ public class DataverseLoader {
                     });
                     actualDatasetDAO.create(actualDataset);
                 }
-                if (doFiles)
+                if (mode.doFiles())
                     loadFiles(shortDoi, v);
             })
         );

--- a/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DataverseLoader.java
@@ -66,7 +66,7 @@ public class DataverseLoader {
 
     @UnitOfWork("hibernate")
     public void deleteSingleDoi(String doi, Mode mode) {
-        deleteByDoi(doi, mode);
+        deleteByDoi(doi.replace("doi:",""), mode);
     }
 
     @UnitOfWork("hibernate")

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -60,7 +60,7 @@ public class EasyFileLoader extends ExpectedLoader {
   }
 
   @UnitOfWork("hibernate")
-  public void deleteFromCsv(CSVParser csvRecords, Mode mode) throws IOException {
+  public void deleteCsvDOIs(CSVParser csvRecords, Mode mode) throws IOException {
     for (CSVRecord r : csvRecords) {
       FedoraToBagCsv fedoraToBagCsv = new FedoraToBagCsv(r);
       if (fedoraToBagCsv.getComment().contains("OK")) {

--- a/src/main/java/nl/knaw/dans/migration/db/ActualDatasetDAO.java
+++ b/src/main/java/nl/knaw/dans/migration/db/ActualDatasetDAO.java
@@ -32,4 +32,21 @@ public class ActualDatasetDAO extends AbstractDAO<ActualDatasetDAO> {
     log.trace(actual.toString());
     currentSession().save(actual);
   }
+
+  public void deleteByDoi(String doi) {
+    log.trace("deleting ActualDataset {}", doi);
+    int r = currentSession()
+        .createQuery("DELETE FROM ActualDataset WHERE doi = :doi")
+        .setParameter("doi", doi)
+        .executeUpdate();
+    log.trace("deleted {} from ActualDataset", r);
+  }
+
+  public void deleteAll() {
+    log.trace("deleting all from ActualDataset");
+    int r = currentSession()
+        .createQuery("DELETE FROM ActualDataset")
+        .executeUpdate();
+    log.trace("deleted {} from ActualDataset", r);
+  }
 }

--- a/src/main/java/nl/knaw/dans/migration/db/ActualFileDAO.java
+++ b/src/main/java/nl/knaw/dans/migration/db/ActualFileDAO.java
@@ -32,4 +32,21 @@ public class ActualFileDAO extends AbstractDAO<ActualFileDAO> {
     log.trace(actual.toString());
     currentSession().save(actual);
   }
+
+  public void deleteByDoi(String doi) {
+    log.trace("deleting ActualFile {}", doi);
+    int r = currentSession()
+        .createQuery("DELETE FROM ActualFile WHERE doi = :doi")
+        .setParameter("doi", doi)
+        .executeUpdate();
+    log.trace("deleted {} from ActualFile", r);
+  }
+
+  public void deleteAll() {
+    log.trace("deleting all from ActualFile");
+    int r = currentSession()
+        .createQuery("DELETE FROM ActualFile")
+        .executeUpdate();
+    log.trace("deleted {} from ActualFile", r);
+  }
 }


### PR DESCRIPTION
Fixes DD-

# Description of changes


# How to test

Run load-from-dataverse with all types of input twice, at least with `start.sh`. DB cleanup should no longer be required.
* [x] no argument meaning loading all datasets
* [x] CSV from fedora-to-bag
* [x] file with UUIDs of bags
* [x] a single doi


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
