### PR TITLE
DD-950 + DD-973: forceInactive + citationDate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ ARGUMENTS
       named arguments:      
         -d DOI, --doi DOI            The DOI for which to load the files,
                                      for example: 'doi:10.17026/dans-xtz-qa6j'
+                                     Use csv with csv and comment column to load multiple DOIs.
         --csv CSV                    CSV file produced by easy-fedora-to-bag
         --mode {ALL,FILES,DATASETS}  files require more writing, dataset require more reading (default: ALL)
         --UUIDs UUIDS                .txt file with bag ids

--- a/src/main/java/nl/knaw/dans/migration/core/AccessCategory.java
+++ b/src/main/java/nl/knaw/dans/migration/core/AccessCategory.java
@@ -18,8 +18,8 @@ package nl.knaw.dans.migration.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static nl.knaw.dans.migration.core.DatasetLicenseHandler.cc0;
-import static nl.knaw.dans.migration.core.DatasetLicenseHandler.dansLicense;
+import static nl.knaw.dans.migration.core.MetadataHandler.cc0;
+import static nl.knaw.dans.migration.core.MetadataHandler.dansLicense;
 
 public enum AccessCategory {
 

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetLicenseHandler.java
@@ -38,12 +38,6 @@ public class DatasetLicenseHandler extends DefaultHandler {
   private StringBuilder chars; // collected since the last startElement
   private String license = null;
 
-  private static DatasetRights initDatasetRights() {
-    DatasetRights datasetRights = new DatasetRights();
-    datasetRights.setDefaultFileRights(new FileRights());
-    return datasetRights;
-  }
-
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {
     chars = new StringBuilder();
@@ -74,10 +68,6 @@ public class DatasetLicenseHandler extends DefaultHandler {
     return saxParserFactory;
   }
 
-  /**
-   * @return key: filepath attribute of file elements
-   * value: content of the elements: accessibleToRights and visibleToRights
-   */
   static public String parseLicense(InputStream xml, AccessCategory accessCategory) {
     DatasetLicenseHandler handler = new DatasetLicenseHandler();
     try {

--- a/src/main/java/nl/knaw/dans/migration/core/DatasetRightsHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/DatasetRightsHandler.java
@@ -78,10 +78,6 @@ public class DatasetRightsHandler extends DefaultHandler {
     return saxParserFactory;
   }
 
-  /**
-   * @return key: filepath attribute of file elements
-   * value: content of the elements: accessibleToRights and visibleToRights
-   */
   static public DatasetRights parseRights(InputStream xml) {
     DatasetRightsHandler handler = new DatasetRightsHandler();
     try {

--- a/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/EasyFileLoader.java
@@ -38,7 +38,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static nl.knaw.dans.migration.core.DatasetLicenseHandler.parseLicense;
 import static nl.knaw.dans.migration.core.HttpHelper.executeReq;
 
 public class EasyFileLoader extends ExpectedLoader {
@@ -88,7 +87,7 @@ public class EasyFileLoader extends ExpectedLoader {
         if (!AccessCategory.NO_ACCESS.equals(solrFields.accessCategory)) {
           byte[] emdBytes = readEmd(csv.getDatasetId())
               .getBytes(StandardCharsets.UTF_8);
-          String license = parseLicense(new ByteArrayInputStream(emdBytes), solrFields.accessCategory);
+          String license = MetadataHandler.parse(new ByteArrayInputStream(emdBytes), solrFields.accessCategory).license;
           expected.setLicenseUrl(license);
         }
         saveExpectedDataset(expected);

--- a/src/main/java/nl/knaw/dans/migration/core/MetadataHandler.java
+++ b/src/main/java/nl/knaw/dans/migration/core/MetadataHandler.java
@@ -28,15 +28,31 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-public class DatasetLicenseHandler extends DefaultHandler {
+public class MetadataHandler extends DefaultHandler {
 
-  private static final Logger log = LoggerFactory.getLogger(DatasetLicenseHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(MetadataHandler.class);
 
   static final String dansLicense = "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf";
   static final String cc0 = "http://creativecommons.org/publicdomain/zero/1.0";
   private static final SAXParserFactory parserFactory = configureFactory();
   private StringBuilder chars; // collected since the last startElement
   private String license = null;
+  private String created = null;
+  private AccessCategory accessCategory;
+
+  /** applies to EMD as well as DDM TODO even DatasetRightsHandler might apply to both  */
+  class DatasetMetadata {
+    final String license;
+    final String created;
+
+    DatasetMetadata(String license, String created) {
+      this.license = license;
+      this.created = created;
+    }
+  }
+  private MetadataHandler(AccessCategory defaultAccessCategory){
+    this.accessCategory = defaultAccessCategory;
+  }
 
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {
@@ -50,7 +66,8 @@ public class DatasetLicenseHandler extends DefaultHandler {
       String s = chars.toString();
       if(s.startsWith("http"))
         this.license = s;
-    }
+    } else if ("created".equalsIgnoreCase(localName))
+        this.created = chars.toString();
   }
 
   @Override
@@ -58,8 +75,9 @@ public class DatasetLicenseHandler extends DefaultHandler {
     chars.append(new String(ch, start, length));
   }
 
-  private String get() {
-    return license;
+  private DatasetMetadata get() {
+    return new DatasetMetadata(Optional.ofNullable(license)
+        .orElse(accessCategory.getDefaultLicense()), created);
   }
 
   private static SAXParserFactory configureFactory() {
@@ -68,12 +86,11 @@ public class DatasetLicenseHandler extends DefaultHandler {
     return saxParserFactory;
   }
 
-  static public String parseLicense(InputStream xml, AccessCategory accessCategory) {
-    DatasetLicenseHandler handler = new DatasetLicenseHandler();
+  static public DatasetMetadata parse(InputStream xml, AccessCategory accessCategory) {
+    MetadataHandler handler = new MetadataHandler(accessCategory);
     try {
       parserFactory.newSAXParser().parse(xml, handler);
-      return Optional.ofNullable(handler.get())
-          .orElse(accessCategory.getDefaultLicense());
+      return handler.get();
     }
     catch (ParserConfigurationException | SAXException | IOException e) {
       throw new RuntimeException(e);

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -25,6 +25,7 @@ import nl.knaw.dans.lib.dataverse.ResultItemDeserializer;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
+import nl.knaw.dans.migration.core.MetadataHandler.DatasetMetadata;
 import nl.knaw.dans.migration.core.tables.ExpectedDataset;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
@@ -105,7 +106,6 @@ public class VaultLoader extends ExpectedLoader {
       }
       if (expectedDataset != null && mode.doDatasets()) {
         expectedDataset.setDepositor(readDepositor(uuid.toString()));
-        expectedDataset.setCitationYear(bagInfo.getCreated().substring(0, 4));
         expectedDataset.setDoi(bagInfo.getDoi());
         expectedDataset.setExpectedVersions(bagSeq.length);
         saveExpectedDataset(expectedDataset);
@@ -128,7 +128,9 @@ public class VaultLoader extends ExpectedLoader {
     } else {
       DatasetRights datasetRights = DatasetRightsHandler.parseRights(new ByteArrayInputStream(ddmBytes));
       expectedDataset = datasetRights.expectedDataset();
-      expectedDataset.setLicenseUrl(DatasetLicenseHandler.parseLicense(new ByteArrayInputStream(ddmBytes), datasetRights.accessCategory));
+      DatasetMetadata metadata = MetadataHandler.parse(new ByteArrayInputStream(ddmBytes), datasetRights.accessCategory);
+      expectedDataset.setCitationYear(metadata.created.substring(0, 4));
+      expectedDataset.setLicenseUrl(metadata.license);
       if (mode.doFiles()) {
         byte[] xmlBytes = readBagFile(uuid, "metadata/", "files.xml").getBytes(StandardCharsets.UTF_8);
         Map<String, FileRights> filesXml = FileRightsHandler.parseRights(new ByteArrayInputStream(xmlBytes));

--- a/src/test/java/nl/knaw/dans/migration/core/MetadataHandlerLicenseTest.java
+++ b/src/test/java/nl/knaw/dans/migration/core/MetadataHandlerLicenseTest.java
@@ -20,39 +20,44 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DatasetLicenseHandlerTest {
+public class MetadataHandlerLicenseTest {
+
+    private String getLicense(InputStream inputStream, AccessCategory accessCategory) {
+        return MetadataHandler.parse(inputStream, accessCategory).license;
+    }
 
     @Test
     public void parseDD_874() throws IOException {
-        String license = DatasetLicenseHandler
-            .parseLicense(new FileInputStream("src/test/resources/ddm/DD-874.xml"), AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
+        InputStream inputStream = new FileInputStream("src/test/resources/ddm/DD-874.xml");
+        String license = getLicense(inputStream, AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
         assertEquals("http://creativecommons.org/licenses/by/4.0", license);
     }
 
     @Test
     public void defaultCC0() {
-        String license = DatasetLicenseHandler
-            .parseLicense(new ByteArrayInputStream("<emd></emd>".getBytes(StandardCharsets.UTF_8)), AccessCategory.OPEN_ACCESS);
-        assertEquals(DatasetLicenseHandler.cc0, license);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("<emd></emd>".getBytes(StandardCharsets.UTF_8));
+        String license = getLicense(inputStream, AccessCategory.OPEN_ACCESS);
+        assertEquals(MetadataHandler.cc0, license);
     }
 
     @Test
     public void defaultDans() {
         ByteArrayInputStream ddmIS = new ByteArrayInputStream("<emd></emd>".getBytes(StandardCharsets.UTF_8));
-        String license = DatasetLicenseHandler.parseLicense(ddmIS, AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
-        assertEquals(DatasetLicenseHandler.dansLicense, license);
+        String license = getLicense(ddmIS, AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS);
+        assertEquals(MetadataHandler.dansLicense, license);
     }
 
     @Test
     public void defaultNone() {
         String ddm = "<emd xmlns:dct=\"http://purl.org/dc/terms/\"><dct:license>accept</dct:license></emd>";
-        String license = DatasetLicenseHandler
-            .parseLicense(new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8)), AccessCategory.NO_ACCESS);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8));
+        String license = getLicense(inputStream, AccessCategory.NO_ACCESS);
         assertNull(license);
     }
 
@@ -60,8 +65,8 @@ public class DatasetLicenseHandlerTest {
     public void alsoForDdm() {
         String start = "<ddm:DDM xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">";
         String ddm = start + "<ddm:dcmiMetadata><dcterms:license xsi:type=\"dcterms:URI\">http://opensource.org/licenses/MIT</dcterms:license></ddm:dcmiMetadata></ddm:DDM>";
-        String license = DatasetLicenseHandler
-            .parseLicense(new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8)), AccessCategory.NO_ACCESS);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(ddm.getBytes(StandardCharsets.UTF_8));
+        String license = getLicense(inputStream, AccessCategory.NO_ACCESS);
         assertEquals("http://opensource.org/licenses/MIT", license);
     }
 }


### PR DESCRIPTION
Fixes
* DD-950: read bag/dataset-metadatafiles with `?forceInactive`
* DD-973: citationYear in loadFromVault from DDM, not from bag-info.txt

# Description of changes

Essential changes: https://github.com/DANS-KNAW/dd-verify-migration/blob/85d84ed559b22ab123cf5c0fa8b1caa036430869/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java#L214

https://github.com/DANS-KNAW/dd-verify-migration/blob/c69aac6b472fdffd61b4df803c6e3b710a93b164/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java#L131-L132

The rest is refactoring of
* reading bag/dataset-metadatafiles
* one of the handlers to parse EMD/DDM no longer return a single string but an immutable class (both XMLs use the same tags for the license and created date)

# How to test

Set `bagStoreBaseUri` and `bagIndexBaseUri` in `etc/config.yml` to a system with https://github.com/DANS-KNAW/easy-bag-store/pull/118 deployed. Otherwise hidden bags will still be inserted into `actual_dataset` as deleted. Resulting log attached to jira issue.

* [x] in separate terminals:

        mvn clean install ; start-hsqldb.sh
        start.sh load-from-vault --mode ALL -u etc/uuids.txt

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
