### PR TITLE
DD-971: strip data/ from expectedPath

### DIFF
--- a/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
@@ -15,18 +15,14 @@
  */
 package nl.knaw.dans.migration.core;
 
-import io.dropwizard.hibernate.UnitOfWork;
 import nl.knaw.dans.migration.core.tables.ExpectedDataset;
 import nl.knaw.dans.migration.core.tables.ExpectedFile;
 import nl.knaw.dans.migration.db.ExpectedDatasetDAO;
 import nl.knaw.dans.migration.db.ExpectedFileDAO;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
 public class ExpectedLoader {
@@ -70,6 +66,7 @@ public class ExpectedLoader {
   }
 
   public void saveExpectedFile(ExpectedFile expected) {
+      expected.setExpectedPath(expected.getExpectedPath().replace("data/",""));
       expectedFileDAO.create(expected);
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/ExpectedLoader.java
@@ -66,7 +66,6 @@ public class ExpectedLoader {
   }
 
   public void saveExpectedFile(ExpectedFile expected) {
-      expected.setExpectedPath(expected.getExpectedPath().replace("data/",""));
       expectedFileDAO.create(expected);
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -144,6 +144,7 @@ public class VaultLoader extends ExpectedLoader {
     log.trace("{} {}", path, fileRights);
     ExpectedFile expectedFile = new ExpectedFile(doi, m, fileRights);
     expectedFile.setEasyFileId(String.valueOf(bagSeqNr));
+    expectedFile.setExpectedPath(expectedFile.getExpectedPath().replace("data/",""));
     saveExpectedFile(expectedFile);
   }
 

--- a/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
+++ b/src/main/java/nl/knaw/dans/migration/core/VaultLoader.java
@@ -144,7 +144,7 @@ public class VaultLoader extends ExpectedLoader {
     log.trace("{} {}", path, fileRights);
     ExpectedFile expectedFile = new ExpectedFile(doi, m, fileRights);
     expectedFile.setEasyFileId(String.valueOf(bagSeqNr));
-    expectedFile.setExpectedPath(expectedFile.getExpectedPath().replace("data/",""));
+    expectedFile.setExpectedPath(expectedFile.getExpectedPath().replaceAll("^data/",""));
     saveExpectedFile(expectedFile);
   }
 


### PR DESCRIPTION
Fixes DD-971: strip data/ from expectedPath

# Description of changes

~The change is applied to load-from-vault and load-from-fedora~

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
